### PR TITLE
Right- vs left-pointing vectors and addition

### DIFF
--- a/Categorical/Object.agda
+++ b/Categorical/Object.agda
@@ -24,9 +24,13 @@ record Products (obj : Set o) : Set (lsuc o) where
     ⊤ : obj
     _×_ : obj → obj → obj
 
-  -- (Right-pointing) vectors and (perfect binary leaf) trees
-  V T : obj → ℕ → obj
-  V A n = ((A ×_) ↑ n) ⊤
+  -- Vectors (left- and right-pointing) and (perfect binary leaf) trees
+  -- Left-pointing needs many fewer parentheses, while right-pointing lets us
+  -- write most significant bit (MSB) on the right (as customary in many
+  -- cultures) while still giving easy access to LSB.
+  Vˡ Vʳ T : obj → ℕ → obj
+  Vˡ A n = ((_× A) ↑ n) ⊤
+  Vʳ A n = ((A ×_) ↑ n) ⊤
   T A n = ((λ z → z × z) ↑ n) A
 
 open Products ⦃ … ⦄ public

--- a/Categorical/Raw.agda
+++ b/Categorical/Raw.agda
@@ -92,13 +92,23 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
 
   open import Data.Nat
 
-  mapⱽ : ∀ n → (a ⇨ b) → (V a n ⇨ V b n)
-  mapⱽ  zero   f = !
-  mapⱽ (suc n) f = f ⊗ mapⱽ n f
+  mapⱽˡ : ∀ n → (a ⇨ b) → (Vˡ a n ⇨ Vˡ b n)
+  mapⱽˡ  zero   f = !
+  mapⱽˡ (suc n) f = mapⱽˡ n f ⊗ f
 
-  unzipⱽ : ∀ n → (V (a × b) n ⇨ V a n × V b n)
-  unzipⱽ  zero   = ! ▵ !
-  unzipⱽ (suc n) = transpose ∘ second (unzipⱽ n)
+  unzipⱽˡ : ∀ n → (Vˡ (a × b) n ⇨ Vˡ a n × Vˡ b n)
+  unzipⱽˡ  zero   = ! ▵ !
+  unzipⱽˡ (suc n) = transpose ∘ first (unzipⱽˡ n)
+
+  -- (V a n × V b n) × (a × b) ⇨ (V a n × a) × (V b n × b)
+
+  mapⱽʳ : ∀ n → (a ⇨ b) → (Vʳ a n ⇨ Vʳ b n)
+  mapⱽʳ  zero   f = !
+  mapⱽʳ (suc n) f = f ⊗ mapⱽʳ n f
+
+  unzipⱽʳ : ∀ n → (Vʳ (a × b) n ⇨ Vʳ a n × Vʳ b n)
+  unzipⱽʳ  zero   = ! ▵ !
+  unzipⱽʳ (suc n) = transpose ∘ second (unzipⱽʳ n)
 
   -- (a × b) × (V a n × V b n) ⇨ (a × V a n) × (b × V b n)
 

--- a/Everything.agda
+++ b/Everything.agda
@@ -7,7 +7,8 @@ import Categorical.Raw
 import Categorical.Homomorphism
 import Categorical.Laws
 
-import Categorical.Comma
+-- -- Categorical.Comma takes a long time to load :(.
+-- import Categorical.Comma
 
 import Functions
 import Ty

--- a/Examples/Add.agda
+++ b/Examples/Add.agda
@@ -48,7 +48,7 @@ fullAdd = second ∨ ∘ inAssocˡ′ halfAdd ∘ second halfAdd
 
 -- TODO: semantic specifications and correctness proofs.
 
-ripple : (a ⇨ᶜ b) → (n : ℕ) → (V a n ⇨ᶜ V b n)
+ripple : (a ⇨ᶜ b) → (n : ℕ) → (Vʳ a n ⇨ᶜ Vʳ b n)
 ripple f  zero   = swap
 ripple f (suc n) = assocˡ ∘ second (ripple f n) ∘ inAssocˡ′ f
 
@@ -57,7 +57,7 @@ ripple f (suc n) = assocˡ ∘ second (ripple f n) ∘ inAssocˡ′ f
 -- b , (bs , cₒ)
 -- (b , bs) , cₒ
 
-rippleAdd : ∀ n → V (Bool × Bool) n ⇨ᶜ V Bool n
+rippleAdd : ∀ n → Vʳ (Bool × Bool) n ⇨ᶜ Vʳ Bool n
 rippleAdd = ripple fullAdd
 
 constˡ : (a × b ⇨ c) → (⊤ ⇨ a) → (b ⇨ c)
@@ -76,7 +76,7 @@ speculate f = cond ∘ second (constˡ f false ▵ constˡ f true)
 -- cond (cᵢ , (f (false , a) , f (true , a)))
 
 V² : obj → ℕ → ℕ → obj
-V² a m n = V (V a n) m
+V² a m n = Vʳ (Vʳ a n) m
 
 carrySelect : ∀ m n → V² (Bool × Bool) m n ⇨ᶜ V² Bool m n
 carrySelect m n = ripple (speculate (ripple fullAdd n)) m

--- a/Examples/Add/Properties.agda
+++ b/Examples/Add/Properties.agda
@@ -8,6 +8,7 @@ open import Data.Nat
 
 open import Categorical.Equiv
 open import Categorical.Raw
+open import Functions.Type
 open import Functions.Raw
 
 open import Examples.Add
@@ -15,9 +16,9 @@ open import Examples.Add
 bval : Bool → ℕ
 bval = bool 0 1
 
-val : ∀ n → V Bool n → ℕ
+val : ∀ n → Vˡ Bool n → ℕ
 val  zero      tt    = zero
-val (suc n) (b , bs) = bval b + val n bs * 2
+val (suc n) (bs , b) = bval b + val n bs * 2
 
 private
   add : ℕ × ℕ → ℕ
@@ -32,7 +33,10 @@ module halfAdd where
   i = bval ⊗ bval
 
   o : Bool × Bool → ℕ
-  o (s , cₒ) = val 2 (s , cₒ , tt)
+  o (cₒ , s) = val 2 ((tt , cₒ) , s)
+
+  -- TODO: Define _、_ to be *left-associative* _,_
+  -- I'll have to replace the current use of _、_
 
   _ : i (𝕗 , 𝕥) ≡ (0 , 1)
   _ = refl≡
@@ -54,41 +58,43 @@ module fullAdd where
   -- λ (c , (a , b)) → let (p , d) = halfAdd (a , b)
   --                       (q , e) = halfAdd (c , p) in (q , e ∨ d)
 
-  i : Bool × (Bool × Bool) → ℕ × (ℕ × ℕ)
-  i = bval ⊗ (bval ⊗ bval)
+  i : (Bool × Bool) × Bool → (ℕ × ℕ) × ℕ
+  i = (bval ⊗ bval) ⊗ bval
 
   o : Bool × Bool → ℕ
-  o (s , cₒ) = val 2 (s , cₒ , tt)
+  o (cₒ , s) = val 2 ((tt , cₒ) , s)
 
-  spec : o ∘ fullAdd ≈ (add ∘ second add) ∘ i
+  spec : o ∘ fullAdd ≈ (add ∘ first add) ∘ i
 
-  -- spec {c , (a , b)} = {!!}
+  spec {(𝕗 , 𝕗) , 𝕗} = refl≡
+  spec {(𝕗 , 𝕗) , 𝕥} = refl≡
+  spec {(𝕗 , 𝕥) , 𝕗} = refl≡
+  spec {(𝕗 , 𝕥) , 𝕥} = refl≡
+  spec {(𝕥 , 𝕗) , 𝕗} = refl≡
+  spec {(𝕥 , 𝕗) , 𝕥} = refl≡
+  spec {(𝕥 , 𝕥) , 𝕗} = refl≡
+  spec {(𝕥 , 𝕥) , 𝕥} = refl≡
 
-  spec {𝕗 , 𝕗 , 𝕗} = refl≡
-  spec {𝕗 , 𝕗 , 𝕥} = refl≡
-  spec {𝕗 , 𝕥 , 𝕗} = refl≡
-  spec {𝕗 , 𝕥 , 𝕥} = refl≡
-  spec {𝕥 , 𝕗 , 𝕗} = refl≡
-  spec {𝕥 , 𝕗 , 𝕥} = refl≡
-  spec {𝕥 , 𝕥 , 𝕗} = refl≡
-  spec {𝕥 , 𝕥 , 𝕥} = refl≡
+module rippleAdd where
 
-module rippleAdd (n : ℕ) where
+  -- rippleAdd : ∀ n → Vˡ (Bool × Bool) n ⇨ᶜ Vˡ Bool n
 
-  -- rippleAdd : ∀ n → V (Bool × Bool) n ⇨ᶜ V Bool n
-  -- rippleAdd = ripple fullAdd
+  module _ (n : ℕ) where
 
-  bvalⁿ : Bool → ℕ
-  bvalⁿ b = (2 ^ n) * bval b
+    bvalₙ : Bool → ℕ
+    bvalₙ b = (2 ^ n) * bval b
 
-  valⁿ : V Bool n → ℕ
-  valⁿ = val n
+    valₙ : Vˡ Bool n → ℕ
+    valₙ = val n
 
-  i : Bool × V (Bool × Bool) n → ℕ × (ℕ × ℕ)
-  i = bval ⊗ (valⁿ ⊗ valⁿ) ∘ unzipⱽ n
+    i : Vˡ (Bool × Bool) n × Bool → (ℕ × ℕ) × ℕ
+    i = (valₙ ⊗ valₙ) ∘ unzipⱽˡ n ⊗ bval
 
-  o : V Bool n × Bool → ℕ
-  o = add ∘ (valⁿ ⊗ bvalⁿ)
+    o : Bool × Vˡ Bool n → ℕ
+    o = add ∘ (bvalₙ ⊗ valₙ)
+
+  -- spec : ∀ n → o n ∘ rippleAdd n ≈ (add ∘ first add) ∘ i n
+  -- spec n = {!!}
 
 -- TODO: Replace ℕ by Fin (2 ^ n) throughout this module, and leave the carry
 -- bit as a bit.

--- a/Examples/Conv.agda
+++ b/Examples/Conv.agda
@@ -32,6 +32,7 @@ conv ((a , b) , v₂) = map avg (zip v₀ (zip v₁ v₂))
    v₁ = shiftʳ b v₂
    v₀ = shiftʳ a v₁
 
+
 mealy : (s × a → b × s) → (∀ {n} → s × Vec a n → Vec b n)
 mealy f (s , []) = []
 mealy f (s , x ∷ xs) = let b , s′ = f (s , x) in b ∷ mealy f (s′ , xs)
@@ -47,10 +48,10 @@ open ≡-Reasoning
 conv₁ : ℕ² × Vec ℕ m → Vec ℕ m
 conv₁ = mealy λ ((a , b) , c) → avg (a , b , c) , (b , c)
 
+-- conv₁-spec : ∀ (((a , b) , xs) : ℕ² × Vec ℕ m) → conv₁ ((a , b) , xs) ≡ conv {m} ((a , b) , xs)
 conv₁-spec : conv₁ ≗ conv {m}
 conv₁-spec (_ , []) = refl
 conv₁-spec ((_ , b) , c ∷ xs) rewrite conv₁-spec ((b , c) , xs) = refl
-
 
 -- Figure 1b
 
@@ -68,7 +69,6 @@ decode₂ ((a , b) ∷ ps) = a ∷ b ∷ decode₂ ps
 conv₂-spec : decode₂ ∘ conv₂ {m} ≗ conv {m * 2} ∘ map₂ decode₂
 conv₂-spec {zero } (_ ,   []  ) = refl
 conv₂-spec {suc _} (_ , p ∷ ps) rewrite conv₂-spec (p , ps) = refl
-
 
 -- Figure 1c
 

--- a/Test.agda
+++ b/Test.agda
@@ -27,21 +27,21 @@ open import Dot
 open import Ty.Utils
 open import Examples.Add
 
-shiftR-swap : ∀ {n} → Bool × V Bool n ⇨ Bool × V Bool n
+shiftR-swap : ∀ {n} → Bool × Vʳ Bool n ⇨ Bool × Vʳ Bool n
 shiftR-swap = swap ∘ shiftR
 
 -- General feedback right-shift register
-fsr : ∀ n → (V Bool n ⇨ Bool) → (V Bool n ⇨ V Bool n)
+fsr : ∀ n → (Vʳ Bool n ⇨ Bool) → (Vʳ Bool n ⇨ Vʳ Bool n)
 fsr _ f = shiftR⇃ ∘ (f ▵ id)
 
-linear : ∀ n → V Bool (suc n) → V Bool (suc n) ⇨ Bool
+linear : ∀ n → Vʳ Bool (suc n) → Vʳ Bool (suc n) ⇨ Bool
 linear zero (c , tt) = unitorᵉʳ
 linear (suc n) (c , cs) = (B.if c then xor else exr) ∘ second (linear n cs)
 
-lfsr : ∀ n → V Bool (suc n) → V Bool (suc n) ⇨ V Bool (suc n)
+lfsr : ∀ n → Vʳ Bool (suc n) → Vʳ Bool (suc n) ⇨ Vʳ Bool (suc n)
 lfsr n cs = fsr (suc n) (linear n cs)
 
-lfsr₅ : V Bool 6 ⇨ V Bool 6
+lfsr₅ : Vʳ Bool 6 ⇨ Vʳ Bool 6
 lfsr₅ = lfsr 5 (𝕥 , 𝕗 , 𝕗 , 𝕥 , 𝕗 , 𝕥 , tt)
 
 
@@ -63,19 +63,20 @@ main = run do
   -- example "not"       not
   -- example "and"       ∧
   -- example "nand"      (not ∘ ∧)
-  -- example "first-not" (first {b = V Bool 2} not)
+  -- example "first-not" (first {b = Vʳ Bool 2} not)
 
   -- example "shiftR-swap-c5" (shiftR-swap {5})
   -- example "lfsr-c5"  lfsr₅   -- wrong
 
-  -- example "half-add"     halfAdd
-  -- example "full-add"     fullAdd
-  -- example "ripple-add-4" (rippleAdd 4)
-  -- example "ripple-add-8" (rippleAdd 8)
+  example "half-add"     halfAdd
+  example "full-add"     fullAdd
+  example "ripple-add-4" (rippleAdd 4)
+  example "ripple-add-8" (rippleAdd 8)
 
-  -- example "carry-select-3x5" (carrySelect 3 5)
-  -- example "carry-select-4x4" (carrySelect 4 4)
-  -- example "carry-select-8x8" (carrySelect 8 8)
-  -- -- example "carry-select-16x16" (carrySelect 16 16)
+  example "carry-select-2x2" (carrySelect 2 2)
+  example "carry-select-3x5" (carrySelect 3 5)
+  example "carry-select-4x4" (carrySelect 4 4)
+  example "carry-select-8x8" (carrySelect 8 8)
+  -- example "carry-select-16x16" (carrySelect 16 16)
 
-  example "curry-and" (curry ∧)
+  -- example "curry-and" (curry ∧)

--- a/Ty/Utils.agda
+++ b/Ty/Utils.agda
@@ -13,10 +13,15 @@ open import Data.Nat
 
 private variable a : Ty
 
--- Todo: rename
-replicate′ : ∀ n → (⊤ ⇨ a) → (⊤ ⇨ V a n)
-replicate′ zero    a = !
-replicate′ (suc n) a = a ⦂ replicate′ n a
+-- -- Todo: rename
+-- replicateʳ′ : ∀ n → (⊤ ⇨ a) → (⊤ ⇨ Vʳ a n)
+-- replicateʳ′ zero    a = !
+-- replicateʳ′ (suc n) a = a ⦂ replicateʳ′ n a
+
+-- Another variation
+replicateʳ : ∀ n → a ⇨ Vʳ a n
+replicateʳ zero    = !
+replicateʳ (suc n) = id ▵ replicateʳ n
 
 shiftR : Bool × a ⇨ a × Bool
 shiftR {`⊤}     = swap


### PR DESCRIPTION
This PR adds left-pointing vectors `Vˡ` and renames `V` to “`Vʳ`”. It also changes `Examples.Add` to use `Vˡ` as mentioned in a comment there:

> Note for a ⇨ᶜ b that the carry-in denotes 0 or 1, while the carry-out denotes (in these examples) 0 or 2^n. Positioning carry-in on the one side and carry-out on the other helps definitions below come out more simply. Left-in and right-out reflect the little-endian interpretation and use of left-pointing vectors, Vˡ. Choosing Vˡ rather than the more common Vʳ reflects the practice of writing least significant bit on the right and most significant on the left.

A syntactic convenience of using right-pointing vectors instead is that `_,_` is right-associative, so right-pointing vectors print as “`a , b , c , d , tt`”, while left-pointing vectors print as “`(((tt , a) , b) , c) , d`”. To eliminate this syntactic burden, I defined the following pattern:

    -- *Left*-associative pairing. Handy for notating left-pointing vectors
    infixl 4 _،_
    pattern _،_ a b = a , b

so that one can write “`tt ، a ، b ، c ، d`” instead as an expression or a pattern. This trick worked, but then Agda wants to change *all* uses of `_,_` patterns into `_،_` when doing automatic proof search and case splitting.

Sigh.

I’m inclined to abandon this whole experiment and accept MSB on the right instead of the left.

Thoughts?
