### PR TITLE
ProductH laws

### DIFF
--- a/Categorical/Arrow.agda
+++ b/Categorical/Arrow.agda
@@ -9,8 +9,8 @@ open import Categorical.Homomorphism
 
 module Categorical.Arrow
    {o}{obj : Set o} {ℓ}(_⇨_ : obj → obj → Set ℓ) ⦃ c : Category _⇨_ ⦄
-   q ⦃ _ : Equivalent q _⇨_ ⦄
-   ⦃ _ : L.Category _⇨_ q ⦄
+   {q} ⦃ _ : Equivalent q _⇨_ ⦄
+   ⦃ _ : L.Category _⇨_ ⦄
  where
 
 open import Categorical.Comma.Type _⇨_ _⇨_ _⇨_ q

--- a/Categorical/Comma/Type.agda
+++ b/Categorical/Comma/Type.agda
@@ -13,9 +13,9 @@ module Categorical.Comma.Type
    {o₃}{obj₃ : Set o₃} {ℓ₃}(_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ c₃ : Category _⇨₃_ ⦄
    q ⦃ _ : Equivalent q _⇨₃_ ⦄
    ⦃ hₒ₁ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ h₁ : Homomorphism _⇨₁_ _⇨₃_ ⦄
-     ⦃ ch₁ : CategoryH _⇨₁_ _⇨₃_ q ⦄
+     ⦃ ch₁ : CategoryH _⇨₁_ _⇨₃_ ⦄
    ⦃ hₒ₂ : Homomorphismₒ obj₂ obj₃ ⦄ ⦃ h₂ : Homomorphism _⇨₂_ _⇨₃_ ⦄
-     ⦃ ch₂ : CategoryH _⇨₂_ _⇨₃_ q ⦄
+     ⦃ ch₂ : CategoryH _⇨₂_ _⇨₃_ ⦄
  where
 
 -- TODO: Define some bundles to reduce syntactic clutter.

--- a/Categorical/Homomorphism.agda
+++ b/Categorical/Homomorphism.agda
@@ -5,6 +5,7 @@ module Categorical.Homomorphism where
 open import Level
 
 open import Categorical.Raw public
+import Categorical.Laws as L
 
 private
   variable
@@ -19,7 +20,7 @@ open import Categorical.Equiv  public
 -- Category homomorphism (functor)
 record CategoryH {obj₁ : Set o₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁)
                  {obj₂ : Set o₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂)
-                 q ⦃ _ : Equivalent q _⇨₂_ ⦄
+                 {q} ⦃ _ : Equivalent q _⇨₂_ ⦄
                  ⦃ _ : Category _⇨₁_ ⦄
                  ⦃ _ : Category _⇨₂_ ⦄
                  ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
@@ -35,14 +36,16 @@ open CategoryH ⦃ … ⦄ public
 id-CategoryH : {obj : Set o} {_⇨_ : obj → obj → Set ℓ}
                {q : Level} ⦃ _ : Equivalent q _⇨_ ⦄
                ⦃ _ : Category _⇨_ ⦄
-             → CategoryH _⇨_ _⇨_ q ⦃ Hₒ = id-Hₒ ⦄ ⦃ H = id-H ⦄
+             → CategoryH _⇨_ _⇨_ ⦃ Hₒ = id-Hₒ ⦄ ⦃ H = id-H ⦄
 id-CategoryH = record { F-id = refl ; F-∘ = refl }
 
 record ProductsH
     (obj₁ : Set o₁) ⦃ _ : Products obj₁ ⦄
-    {obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄ (_⇨₂′_ : obj₂ → obj₂ → Set ℓ₂)
+    {obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
+    (_⇨₂′_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂′_ ⦄
     ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
-    : Set (o₁ ⊔ o₂ ⊔ ℓ₂) where
+    {q} ⦃ _ : Equivalent q _⇨₂′_ ⦄
+    : Set (o₁ ⊔ o₂ ⊔ ℓ₂ ⊔ q) where
   private infix 0 _⇨₂_; _⇨₂_ = _⇨₂′_
   field
     -- https://ncatlab.org/nlab/show/monoidal+functor
@@ -53,6 +56,8 @@ record ProductsH
     ε⁻¹ : Fₒ ⊤ ⇨₂ ⊤
     μ⁻¹ : {a b : obj₁} → Fₒ (a × b) ⇨₂ Fₒ a × Fₒ b
 
+    ε⁻¹∘ε : ε⁻¹ ∘ ε ≈ id
+
   -- -- Maybe useful along with second′ and _⊗′_
   -- first′ : {a b c : obj₁} ⦃ _ : Cartesian _⇨₂_ ⦄
   --        → (Fₒ a ⇨₂ Fₒ c) → (Fₒ (a × b) ⇨₂ Fₒ (c × b))
@@ -62,19 +67,21 @@ open ProductsH ⦃ … ⦄ public
 
 id-ProductsH : ∀ {obj : Set o} ⦃ _ : Products obj ⦄
                  {_⇨_ : obj → obj → Set ℓ} ⦃ _ : Category _⇨_ ⦄
+                 {q} ⦃ _ : Equivalent q _⇨_ ⦄ ⦃ _ : L.Category _⇨_ ⦄
              → ProductsH obj _⇨_ ⦃ Hₒ = id-Hₒ ⦄
-id-ProductsH = record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id }
+id-ProductsH =
+  record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id ; ε⁻¹∘ε = L.identityˡ }
 
 -- Cartesian homomorphism (cartesian functor)
 record CartesianH
          {obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄ (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁)
          {obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄ (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂)
-         q ⦃ _ : Equivalent q _⇨₂_ ⦄
+         {q} ⦃ _ : Equivalent q _⇨₂_ ⦄
          ⦃ _ : Cartesian _⇨₁_ ⦄
          ⦃ _ : Cartesian _⇨₂_ ⦄
          ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
          ⦃ H : Homomorphism _⇨₁_ _⇨₂_ ⦄
-         ⦃ H : ProductsH obj₁ _⇨₂_ ⦄
+         ⦃ pH : ProductsH obj₁ _⇨₂_ ⦄
        : Set (o₁ ⊔ ℓ₁ ⊔ o₂ ⊔ ℓ₂ ⊔ q) where
   field
     F-!   : ∀ {a : obj₁} → Fₘ {a = a} ! ≈ ε ∘ !
@@ -120,7 +127,7 @@ id-booleanH = record { β = id }
 record LogicH
     {obj₁ : Set o₁} (_⇨₁′_ : obj₁ → obj₁ → Set ℓ₁)
     {obj₂ : Set o₂} (_⇨₂′_ : obj₂ → obj₂ → Set ℓ₂)
-    q ⦃ _ : Equivalent q _⇨₂′_ ⦄
+    {q} ⦃ _ : Equivalent q _⇨₂′_ ⦄
     ⦃ _ : Boolean obj₁ ⦄ ⦃ _ : Products obj₁ ⦄ ⦃ _ : Logic _⇨₁′_ ⦄
     ⦃ _ : Boolean obj₂ ⦄ ⦃ _ : Products obj₂ ⦄ ⦃ _ : Logic _⇨₂′_ ⦄
     ⦃ _ : Cartesian _⇨₂′_ ⦄

--- a/Everything.agda
+++ b/Everything.agda
@@ -7,7 +7,7 @@ import Categorical.Raw
 import Categorical.Homomorphism
 import Categorical.Laws
 
--- Categorical.Comma.Raw takes a long time to load :(
+-- import Categorical.Comma
 import Categorical.Comma.Type
 
 import Functions

--- a/Examples/Add.agda
+++ b/Examples/Add.agda
@@ -1,6 +1,5 @@
 {-# OPTIONS --safe --without-K #-}
 
-open import Level using (0ℓ)
 open import Data.Nat
 
 open import Categorical.Raw

--- a/Examples/Add/Properties.agda
+++ b/Examples/Add/Properties.agda
@@ -2,8 +2,6 @@
 
 module Examples.Add.Properties where
 
-open import Level using (0ℓ)
-
 open import Data.Unit using (tt)
 open import Data.Product using (_,_)
 open import Data.Nat
@@ -12,7 +10,7 @@ open import Categorical.Equiv
 open import Categorical.Raw
 open import Functions.Raw
 open import Functions.Laws
-open import Categorical.Arrow Function 0ℓ
+open import Categorical.Arrow Function
 
 open import Examples.Add
 

--- a/Functions.agda
+++ b/Functions.agda
@@ -1,7 +1,5 @@
 {-# OPTIONS --safe --without-K #-}
 
-open import Level
-
 module Functions where
 
 open import Functions.Laws public  -- exports Functions.Type & Functions.Raw

--- a/Functions/Laws.agda
+++ b/Functions/Laws.agda
@@ -22,7 +22,7 @@ module →-laws-instances where
                 )
   instance
 
-    category : Category Function zero
+    category : Category Function
     category = record
       { identityˡ = λ _ → refl≡
       ; identityʳ = λ _ → refl≡
@@ -31,7 +31,7 @@ module →-laws-instances where
                       trans≡ (h≈k (f x)) (cong k (f≈g x)) }
       }
 
-    cartesian : Cartesian Function zero
+    cartesian : Cartesian Function
     cartesian = record
       { ∀× = equivalence
           (λ k≈f▵g → (λ x → cong exl (k≈f▵g x)) , (λ x → cong exr (k≈f▵g x)))
@@ -41,7 +41,7 @@ module →-laws-instances where
 
     module ccc (extensionality : Extensionality _ _) where
 
-      cartesianClosed : CartesianClosed Function zero
+      cartesianClosed : CartesianClosed Function
       cartesianClosed = record
         { ∀⇛ = equivalence
             (λ g≈f (x , y) → sym≡ (cong (λ h → h y) (g≈f x)))

--- a/Linearize/Raw.agda
+++ b/Linearize/Raw.agda
@@ -13,6 +13,7 @@ module Linearize.Raw {o}{objₘ : Set o} ⦃ _ : Products objₘ ⦄ ⦃ _ : Exp
              ⦃ Hₒ : Homomorphismₒ obj objₘ ⦄
              ⦃ Hₚ : Homomorphism _⇨ₚ_ _⇨ₘ_ ⦄
              ⦃ Hᵣ : Homomorphism _⇨ᵣ_ _⇨ₘ_ ⦄
+             {q} ⦃ _ : Equivalent q _⇨ₘ_ ⦄
              ⦃ _ : ProductsH obj _⇨ₘ_ ⦄ ⦃ _ : ExponentialsH obj _⇨ₘ_ ⦄
   where
 

--- a/Primitive.agda
+++ b/Primitive.agda
@@ -2,8 +2,6 @@
 
 -- Symbolic logic primitives with mapping to another category
 
-open import Level
-
 open import Categorical.Raw
 open import Categorical.Equiv
 
@@ -11,9 +9,9 @@ module Primitive
     {o ℓ} {obj : Set o}
     ⦃ _ : Products obj ⦄ ⦃ _ : Boolean obj ⦄ ⦃ _ : Exponentials obj ⦄
     (_↠_ : obj → obj → Set ℓ) ⦃ _ : Logic _↠_ ⦄
-    (q : Level) ⦃ _ : Equivalent q _↠_ ⦄
+    {q} ⦃ _ : Equivalent q _↠_ ⦄
   where
 
 open import Primitive.Raw          _↠_   public
--- open import Primitive.Homomorphism _↠_ q public
+-- open import Primitive.Homomorphism _↠_ public
 

--- a/Routing/Homomorphism.agda
+++ b/Routing/Homomorphism.agda
@@ -1,6 +1,5 @@
 {-# OPTIONS --safe --without-K #-}
 
-open import Level
 open import Function using (id) renaming (_∘_ to _∙_)
 open import Data.Product using (_,_)
 open import Relation.Binary.PropositionalEquality
@@ -9,6 +8,7 @@ open import Relation.Binary.PropositionalEquality
 module Routing.Homomorphism where
 
 open import Functions.Raw
+open import Functions.Laws
 open import Routing.Raw public
 open import Ty
 open import Index
@@ -65,13 +65,13 @@ swizzle-∘ g f x =
 
 instance
 
-  categoryH : CategoryH _⇨_ Function 0ℓ
+  categoryH : CategoryH _⇨_ Function
   categoryH = record
     { F-id = λ {a} → swizzle-id a
     ; F-∘  = λ { {g = mk g} {mk f} → swizzle-∘ g f }
     }
 
-  cartesianH : CartesianH _⇨_ Function 0ℓ
+  cartesianH : CartesianH _⇨_ Function
   cartesianH = record
     { F-!   = λ _ → ≡-refl
     ; F-exl = λ {a b} (x , y) → tabulate∘lookup {a = a} x

--- a/SSA.agda
+++ b/SSA.agda
@@ -4,7 +4,6 @@
 
 module SSA where
 
-open import Level using (0ℓ) -- temp?
 open import Data.Product using (_,_)
 open import Data.Nat using (ℕ; suc; zero)
 open import Data.String hiding (toList; show)

--- a/Test.agda
+++ b/Test.agda
@@ -13,6 +13,7 @@ open import IO
 open import Show
 open import Categorical.Raw
 open import Functions.Raw
+open import Functions.Laws
 open import Ty
 open import Index
 open import Primitive.Raw Function renaming (_⇨_ to _⇨ₚ_)
@@ -68,14 +69,14 @@ main = run do
   -- example "shiftR-swap-c5" (shiftR-swap {5})
   -- example "lfsr-c5"  lfsr₅   -- wrong
 
-  -- example "half-add"     halfAdd
-  -- example "full-add"     fullAdd
-  -- example "ripple-add-4" (rippleAdd 4)
-  -- example "ripple-add-8" (rippleAdd 8)
+  example "half-add"     halfAdd
+  example "full-add"     fullAdd
+  example "ripple-add-4" (rippleAdd 4)
+  example "ripple-add-8" (rippleAdd 8)
 
   -- example "carry-select-3x5" (carrySelect 3 5)
   -- example "carry-select-4x4" (carrySelect 4 4)
   -- example "carry-select-8x8" (carrySelect 8 8)
   -- -- example "carry-select-16x16" (carrySelect 16 16)
 
-  example "curry-and" (curry ∧)
+  -- example "curry-and" (curry ∧)

--- a/Ty.agda
+++ b/Ty.agda
@@ -12,6 +12,7 @@ data Ty : Set where
   _`⇛_  : Ty → Ty → Ty
 
 open import Categorical.Homomorphism
+import Categorical.Laws as L
 
 module ty-instances where
 
@@ -40,8 +41,9 @@ module ty-instances where
     productsH : ∀ {ℓ o}{obj : Set o} ⦃ _ : Products obj ⦄
                   ⦃ _ : Boolean obj ⦄ ⦃ _ : Exponentials obj ⦄
                   {_⇨_ : obj → obj → Set ℓ} ⦃ _ : Category _⇨_ ⦄
+                  {q} ⦃ _ : Equivalent q _⇨_ ⦄ ⦃ _ : L.Category _⇨_ ⦄
              → ProductsH Ty _⇨_
-    productsH = record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id }
+    productsH = record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id ; ε⁻¹∘ε = L.identityˡ }
 
     exponentialsH : ∀ {ℓ o}{obj : Set o} ⦃ _ : Products obj ⦄
                     ⦃ _ : Boolean obj ⦄ ⦃ _ : Exponentials obj ⦄


### PR DESCRIPTION
Start adding inversion laws to `ProductH`. Led to some other changes, including making `q` (`Equivalent` level) implicit. I hadn’t thought `q` would be inferred, but it is.
