### PR TITLE
Cartesian comma

### DIFF
--- a/Categorical/Arrow.agda
+++ b/Categorical/Arrow.agda
@@ -13,7 +13,7 @@ module Categorical.Arrow
    ⦃ _ : L.Category _⇨_ ⦄
  where
 
-open import Categorical.Comma.Type _⇨_ _⇨_ _⇨_ q
+open import Categorical.Comma.Type _⇨_ _⇨_ _⇨_
         ⦃ hₒ₁ = id-Hₒ ⦄ ⦃ h₁ = id-H ⦄ ⦃ ch₁ = id-CategoryH ⦄
         ⦃ hₒ₂ = id-Hₒ ⦄ ⦃ h₂ = id-H ⦄ ⦃ ch₂ = id-CategoryH ⦄
      public

--- a/Categorical/Comma/Raw.agda
+++ b/Categorical/Comma/Raw.agda
@@ -8,17 +8,22 @@ open import Categorical.Laws as L hiding (Category; Cartesian)
 open import Categorical.Homomorphism
 
 module Categorical.Comma.Raw
-   {o₁}{obj₁ : Set o₁} {ℓ₁}(_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄
-   {o₂}{obj₂ : Set o₂} {ℓ₂}(_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄
-   {o₃}{obj₃ : Set o₃} {ℓ₃}(_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄
-   q ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ q ⦄
+   {o₁}{obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄
+     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Cartesian _⇨₁_ ⦄
+   {o₂}{obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
+     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Cartesian _⇨₂_ ⦄
+   {o₃}{obj₃ : Set o₃} ⦃ _ : Products obj₃ ⦄
+     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Cartesian _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₃_ ⦄
-     ⦃ _ : CategoryH _⇨₁_ _⇨₃_ q ⦄
+     ⦃ _ : CategoryH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄
+     ⦃ _ : CartesianH _⇨₁_ _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₂ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₂_ _⇨₃_ ⦄
-     ⦃ _ : CategoryH _⇨₂_ _⇨₃_ q ⦄
+     ⦃ _ : CategoryH _⇨₂_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
+     ⦃ _ : CartesianH _⇨₂_ _⇨₃_ ⦄
  where
 
-open import Categorical.Comma.Type _⇨₁_ _⇨₂_ _⇨₃_ q public
+open import Categorical.Comma.Type _⇨₁_ _⇨₂_ _⇨₃_ public
 
 module comma-raw-instances where
 
@@ -30,103 +35,127 @@ module comma-raw-instances where
     category = record
       { id  = λ {a} → mk id id
           (begin
-             Fₘ id ∘ h a
-           ≈⟨ ∘≈ˡ F-id ⟩
-             id ∘ h a
-           ≈⟨ identityˡ ⟩
-             h a
-           ≈˘⟨ identityʳ ⟩
-             h a ∘ id
-           ≈˘⟨ ∘≈ʳ F-id ⟩
              h a ∘ Fₘ id
+           ≈⟨ ∘≈ʳ F-id ⟩
+             h a ∘ id
+           ≈⟨ identityʳ ⟩
+             h a
+           ≈˘⟨ identityˡ ⟩
+             id ∘ h a
+           ≈˘⟨ ∘≈ˡ F-id ⟩
+             Fₘ id ∘ h a
            ∎)
       ; _∘_ = λ {a b c} (mk g₁ g₂ comm-g) (mk f₁ f₂ comm-f) →
           mk (g₁ ∘ f₁) (g₂ ∘ f₂)
            (begin
-              Fₘ (g₂ ∘ f₂) ∘ h a
-            ≈⟨ ∘≈ˡ F-∘ ⟩
-              (Fₘ g₂ ∘ Fₘ f₂) ∘ h a
-            ≈⟨ assoc ⟩
-              Fₘ g₂ ∘ (Fₘ f₂ ∘ h a)
-            ≈⟨ ∘≈ʳ comm-f ⟩
-              Fₘ g₂ ∘ (h b ∘ Fₘ f₁)
-            ≈˘⟨ assoc ⟩
-              (Fₘ g₂ ∘ h b) ∘ Fₘ f₁
-            ≈⟨ ∘≈ˡ comm-g ⟩
-              (h c ∘ Fₘ g₁) ∘ Fₘ f₁
-            ≈⟨ assoc ⟩
-              h c ∘ (Fₘ g₁ ∘ Fₘ f₁)
-            ≈˘⟨ ∘≈ʳ F-∘ ⟩
               h c ∘ Fₘ (g₁ ∘ f₁)
+            ≈⟨ ∘≈ʳ F-∘ ⟩
+              h c ∘ (Fₘ g₁ ∘ Fₘ f₁)
+            ≈˘⟨ assoc ⟩
+              (h c ∘ Fₘ g₁) ∘ Fₘ f₁
+            ≈⟨ ∘≈ˡ comm-g ⟩
+              (Fₘ g₂ ∘ h b) ∘ Fₘ f₁
+            ≈⟨ assoc ⟩
+              Fₘ g₂ ∘ (h b ∘ Fₘ f₁)
+            ≈⟨ ∘≈ʳ comm-f ⟩
+              Fₘ g₂ ∘ (Fₘ f₂ ∘ h a)
+            ≈˘⟨ assoc ⟩
+              (Fₘ g₂ ∘ Fₘ f₂) ∘ h a
+            ≈˘⟨ ∘≈ˡ F-∘ ⟩
+              Fₘ (g₂ ∘ f₂) ∘ h a
             ∎)
       }
 
-{-
-
-    -- TODO: Cartesian, CartesianClosed, and Logic.
-
-    products : ⦃ p₁ : Products obj₁ ⦄ ⦃ p₂ : Products obj₂ ⦄ ⦃ p₃ : Products obj₃ ⦄
-               ⦃ c₃ : Cartesian _⇨₃_ ⦄
-               ⦃ ph₁ : ProductsH obj₁ _⇨₃_ ⦄ ⦃ ph₂ : ProductsH obj₂ _⇨₃_ ⦄ 
-             → Products Obj
-
-    products ⦃ p₁ = p₁ ⦄ ⦃ p₂ = p₂ ⦄ ⦃ p₃ = p₃ ⦄
-             = record { ⊤ = mk {mp₁.⊤}{mp₂.⊤} {!!}
-                                      -- ({!!} ∘ {!!})
-                                      -- (ε {obj₁ = obj₂}{_⇨₂′_ = _⇨₃_} ∘ ε⁻¹ {obj₁ = obj₁}{_⇨₂′_ = _⇨₃_})
-                            -- mk {⊤}{⊤} (ε ∘ Products.ε⁻¹ p₁)
-                                      -- (ε ∘ ε⁻¹)
-
-                      -- ; _×_ = λ (mk h) (mk k) → mk (μ ∘ (h ⊗ k) ∘ μ⁻¹)
-
-                      -- ; _×_ = λ (mk {σ₁}{σ₂} h) (mk {τ₁}{τ₂} k) →
-                      --              mk {σ₁ × τ₁} {σ₂ × τ₂} (μ ∘ (h ⊗ k) ∘ μ⁻¹)
-
-                      ; _×_ = λ (mk {σ₁}{σ₂} h) (mk {τ₁}{τ₂} k) →
-                                   {!!}
-
+    products : Products Obj
+    products = record { ⊤   = mk (ε ∘ ε⁻¹)
+                      ; _×_ = λ (mk h) (mk k) → mk (μ ∘ (h ⊗ k) ∘ μ⁻¹)
                       }
-      where module mp₁ = Products p₁
-            module mp₂ = Products p₂
-            module mp₃ = Products p₃
 
-            ε⁻¹* : Fₒ mp₁.⊤ ⇨₃ mp₃.⊤
-            ε⁻¹* = ε⁻¹
-            ε* : mp₃.⊤ ⇨₃ Fₒ mp₂.⊤
-            ε* = ε
-            ⊤* : Fₒ mp₁.⊤ ⇨₃ Fₒ mp₂.⊤
-            ⊤* = ε* ∘ ε⁻¹*
+    cartesian : Cartesian _⇨_
+    cartesian = record
+      { ! = λ {a} → mk ! !
+         (begin
+            h ⊤ ∘ Fₘ !
+          ≡⟨⟩
+            (ε ∘ ε⁻¹) ∘ Fₘ !
+          ≈⟨ ∘≈ʳ F-! ⟩
+            (ε ∘ ε⁻¹) ∘ (ε ∘ !)
+          ≈⟨ cancelInner ε⁻¹∘ε ⟩
+            ε ∘ !
+          ≈˘⟨ ∘≈ʳ ∀⊤ ⟩  -- Universal property for !
+            ε ∘ (! ∘ h a)
+          ≈˘⟨ assoc ⟩
+            (ε ∘ !) ∘ h a
+          ≈˘⟨ ∘≈ˡ F-! ⟩
+            Fₘ ! ∘ h a
+          ∎)
+      ; exl = λ {a b} → mk exl exl
+          (begin
+             h a ∘ Fₘ exl
+           ≈˘⟨ ∘≈ʳ (identityʳ • ∘≈ʳ μ∘μ⁻¹) ⟩
+             h a ∘ (Fₘ exl ∘ μ ∘ μ⁻¹)
+           ≈⟨ ∘≈ʳ (∘≈ˡ F-exl • sym assoc) ⟩
+              h a ∘ (exl ∘ μ⁻¹)
+           ≈˘⟨ assoc ⟩
+              (h a ∘ exl) ∘ μ⁻¹
+           ≈˘⟨ ∘≈ˡ exl∘▵ ⟩
+              (exl ∘ (h a ⊗ h b)) ∘ μ⁻¹
+           ≈⟨ assoc ⟩
+              exl ∘ (h a ⊗ h b) ∘ μ⁻¹
+           ≈˘⟨ ∘≈ˡ F-exl ⟩
+             (Fₘ exl ∘ μ) ∘ (h a ⊗ h b) ∘ μ⁻¹
+           ≈⟨ ∘≈ʳ (sym assoc) • assoc ⟩
+             Fₘ exl ∘ (μ ∘ (h a ⊗ h b)) ∘ μ⁻¹
+           ≈⟨ ∘≈ʳ assoc ⟩
+             Fₘ exl ∘ μ ∘ (h a ⊗ h b) ∘ μ⁻¹
+           ≡⟨⟩
+             Fₘ exl ∘ h (a × b)
+           ∎)
+      ; exr = λ {a b} → mk exr exr
+          (begin
+             h b ∘ Fₘ exr
+           ≈˘⟨ ∘≈ʳ (identityʳ • ∘≈ʳ μ∘μ⁻¹) ⟩
+             h b ∘ (Fₘ exr ∘ μ ∘ μ⁻¹)
+           ≈⟨ ∘≈ʳ (∘≈ˡ F-exr • sym assoc) ⟩
+              h b ∘ (exr ∘ μ⁻¹)
+           ≈˘⟨ assoc ⟩
+              (h b ∘ exr) ∘ μ⁻¹
+           ≈˘⟨ ∘≈ˡ exr∘▵ ⟩
+              (exr ∘ (h a ⊗ h b)) ∘ μ⁻¹
+           ≈⟨ assoc ⟩
+              exr ∘ (h a ⊗ h b) ∘ μ⁻¹
+           ≈˘⟨ ∘≈ˡ F-exr ⟩
+             (Fₘ exr ∘ μ) ∘ (h a ⊗ h b) ∘ μ⁻¹
+           ≈⟨ ∘≈ʳ (sym assoc) • assoc ⟩
+             Fₘ exr ∘ (μ ∘ (h a ⊗ h b)) ∘ μ⁻¹
+           ≈⟨ ∘≈ʳ assoc ⟩
+             Fₘ exr ∘ μ ∘ (h a ⊗ h b) ∘ μ⁻¹
+           ≡⟨⟩
+             Fₘ exr ∘ h (a × b)
+           ∎)
+      ; _▵_ = λ {a c d} (mk f₁ f₂ comm-f) (mk g₁ g₂ comm-g) →
+          mk (f₁ ▵ g₁) (f₂ ▵ g₂)
+            (begin
+               h (c × d) ∘ Fₘ (f₁ ▵ g₁)
+             ≈⟨ ∘≈ʳ F-▵ ⟩
+               (μ ∘ (h c ⊗ h d) ∘ μ⁻¹) ∘ (μ ∘ (Fₘ f₁ ▵ Fₘ g₁))
+             ≈˘⟨ ∘≈ˡ assoc ⟩
+               ((μ ∘ (h c ⊗ h d)) ∘ μ⁻¹) ∘ (μ ∘ (Fₘ f₁ ▵ Fₘ g₁))
+             ≈⟨ cancelInner μ⁻¹∘μ ⟩
+               (μ ∘ (h c ⊗ h d)) ∘ (Fₘ f₁ ▵ Fₘ g₁)
+             ≈⟨ assoc ⟩
+               μ ∘ (h c ⊗ h d) ∘ (Fₘ f₁ ▵ Fₘ g₁)
+             ≈⟨ ∘≈ʳ ⊗∘▵ ⟩
+               μ ∘ (h c ∘ Fₘ f₁ ▵ h d ∘ Fₘ g₁)
+             ≈⟨ ∘≈ʳ (▵≈ comm-f comm-g) ⟩
+               μ ∘ (Fₘ f₂ ∘ h a ▵ Fₘ g₂ ∘ h a)
+             ≈˘⟨ ∘≈ʳ ▵∘ ⟩
+               μ ∘ ((Fₘ f₂ ▵ Fₘ g₂) ∘ h a)
+             ≈˘⟨ assoc ⟩
+               (μ ∘ (Fₘ f₂ ▵ Fₘ g₂)) ∘ h a
+             ≈˘⟨ ∘≈ˡ F-▵ ⟩
+               Fₘ (f₂ ▵ g₂) ∘ h a
+             ∎)
+      }
 
--- The problem is that I'm getting one cat3 with the module and another in the
--- cart3. I can take a Cartesian in the module instead, but next we'll have to
--- require CartesianClosed, which precludes some categories. I could remove
--- change the Category *field* in Cartesian to an instance parameter and
--- likewise for CartesianClosed, further bloating signatures. Is there another
--- solution? I think I need some Agda advice. If I do replace more fields with
--- parameters, also add bundles, so at least clients are uncluttered.
-
--}
-
--- record Obj : Set (o₁ ⊔ o₂ ⊔ ℓ₃) where
---   constructor mk
---   field
---     { τ₁ } : obj₁
---     { τ₂ } : obj₂
---     h : Fₒ τ₁ ⇨₃ Fₒ τ₂
-
--- goal Fₒ ⊤₁ ⇨₃ Fₒ ⊤₂
-
--- ε⁻¹ : Fₒ ⊤ ⇨₃ ⊤
--- ε : ⊤ ⇨₃ Fₒ ⊤
-
--- μ⁻¹ : Fₒ (σ₁ × τ₁) ⇨₃ Fₒ σ₁ × Fₒ τ₁
--- h ⊗ k : Fₒ σ₁ × Fₒ τ₁ ⇨ Fₒ σ₂ × Fₒ τ₂
--- μ : Fₒ σ₂ × Fₒ τ₂ ⇨₃ Fₒ (σ₂ × τ₂)
-
-
-
--- Fₒ (σ₁ × τ₁) ⇨₃ Fₒ (σ₂ × τ₂)
-
-
-    -- cartesian : CartesianClosed _⇨_
-    -- cartesian = ?
+    -- TODO: CartesianClosed and Logic.

--- a/Categorical/Comma/Type.agda
+++ b/Categorical/Comma/Type.agda
@@ -11,7 +11,7 @@ module Categorical.Comma.Type
    {o₁}{obj₁ : Set o₁} {ℓ₁}(_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ c₁ : Category _⇨₁_ ⦄
    {o₂}{obj₂ : Set o₂} {ℓ₂}(_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ c₂ : Category _⇨₂_ ⦄
    {o₃}{obj₃ : Set o₃} {ℓ₃}(_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ c₃ : Category _⇨₃_ ⦄
-   q ⦃ _ : Equivalent q _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₃_ ⦄
    ⦃ hₒ₁ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ h₁ : Homomorphism _⇨₁_ _⇨₃_ ⦄
      ⦃ ch₁ : CategoryH _⇨₁_ _⇨₃_ ⦄
    ⦃ hₒ₂ : Homomorphismₒ obj₂ obj₃ ⦄ ⦃ h₂ : Homomorphism _⇨₂_ _⇨₃_ ⦄

--- a/Categorical/Homomorphism.agda
+++ b/Categorical/Homomorphism.agda
@@ -5,7 +5,8 @@ module Categorical.Homomorphism where
 open import Level
 
 open import Categorical.Raw public
-import Categorical.Laws as L
+open import Categorical.Laws as L
+       hiding (Category; Cartesian; CartesianClosed)
 
 private
   variable
@@ -57,6 +58,10 @@ record ProductsH
     μ⁻¹ : {a b : obj₁} → Fₒ (a × b) ⇨₂ Fₒ a × Fₒ b
 
     ε⁻¹∘ε : ε⁻¹ ∘ ε ≈ id
+    ε∘ε⁻¹ : ε ∘ ε⁻¹ ≈ id
+
+    μ⁻¹∘μ : μ⁻¹ ∘ μ {a}{b} ≈ id
+    μ∘μ⁻¹ : μ ∘ μ⁻¹ {a}{b} ≈ id
 
   -- -- Maybe useful along with second′ and _⊗′_
   -- first′ : {a b c : obj₁} ⦃ _ : Cartesian _⇨₂_ ⦄
@@ -70,7 +75,10 @@ id-ProductsH : ∀ {obj : Set o} ⦃ _ : Products obj ⦄
                  {q} ⦃ _ : Equivalent q _⇨_ ⦄ ⦃ _ : L.Category _⇨_ ⦄
              → ProductsH obj _⇨_ ⦃ Hₒ = id-Hₒ ⦄
 id-ProductsH =
-  record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id ; ε⁻¹∘ε = L.identityˡ }
+  record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id
+         ; ε⁻¹∘ε = L.identityˡ ; ε∘ε⁻¹ = L.identityˡ
+         ; μ⁻¹∘μ = L.identityˡ ; μ∘μ⁻¹ = L.identityˡ
+         }
 
 -- Cartesian homomorphism (cartesian functor)
 record CartesianH
@@ -111,18 +119,34 @@ record BooleanH
     (obj₁ : Set o₁) ⦃ _ : Boolean obj₁ ⦄
     {obj₂ : Set o₂} ⦃ _ : Boolean obj₂ ⦄ (_⇨₂′_ : obj₂ → obj₂ → Set ℓ₂)
     ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
-    : Set (o₁ ⊔ o₂ ⊔ ℓ₂) where
+    -- {q : Level} ⦃ _ : Equivalent q _⇨₂′_ ⦄
+    : Set (o₁ ⊔ o₂ ⊔ ℓ₂ {- ⊔ q -}) where
   private infix 0 _⇨₂_; _⇨₂_ = _⇨₂′_
   field
-    β : Bool ⇨₂ Fₒ Bool
+    β   : Bool ⇨₂ Fₒ Bool
+    β⁻¹ : Fₒ Bool ⇨₂ Bool
+  
+    -- -- Oops. These two need Category _⇨₂_, which we won't always have,
+    -- -- e.g., for primitives.
+    -- -- TODO: Maybe split off StrongBooleanH with β⁻¹ and the inverse
+    -- -- properties, and similarly for ProductsH.
+    -- β⁻¹∘β : β⁻¹ ∘ β ≈ id
+    -- β∘β⁻¹ : β ∘ β⁻¹ ≈ id
 
 open BooleanH ⦃ … ⦄ public
 
 id-booleanH : {obj : Set o} ⦃ _ : Boolean obj ⦄
               {_⇨₁_ : obj → obj → Set ℓ₁} {_⇨₂_ : obj → obj → Set ℓ₂}
-              ⦃ cat₂ : Category _⇨₂_ ⦄
+              ⦃ _ : Category _⇨₂_ ⦄
+              -- {q : Level} ⦃ _ : Equivalent q _⇨₂_ ⦄
+              -- ⦃ _ : L.Category _⇨₂_ ⦃ rcat = cat₂ ⦄ ⦄
             → BooleanH obj _⇨₂_ ⦃ Hₒ = id-Hₒ ⦄
-id-booleanH = record { β = id }
+id-booleanH = record
+  { β   = id
+  ; β⁻¹ = id
+  -- ; β⁻¹∘β = {!identityˡ!}
+  -- ; β∘β⁻¹ = {!identityˡ!}
+  }
 
 record LogicH
     {obj₁ : Set o₁} (_⇨₁′_ : obj₁ → obj₁ → Set ℓ₁)

--- a/Categorical/Laws.agda
+++ b/Categorical/Laws.agda
@@ -3,12 +3,13 @@
 module Categorical.Laws where
 
 open import Level
-
-open import Categorical.Raw as R hiding (Category; Cartesian; CartesianClosed)
-open import Categorical.Equiv
 open import Relation.Binary.PropositionalEquality using (_≡_)
 open import Function.Equivalence using (_⇔_; module Equivalence)
 open import Function.Equality using (_⟨$⟩_)
+
+open import Categorical.Raw as R hiding (Category; Cartesian; CartesianClosed)
+open import Categorical.Equiv
+open import Functions.Raw
 
 open Equivalence
 open ≈-Reasoning
@@ -21,16 +22,23 @@ private
 
 record Category {obj : Set o} (_⇨′_ : obj → obj → Set ℓ)
                 {q} ⦃ equiv : Equivalent q _⇨′_ ⦄
-                ⦃ _ : R.Category _⇨′_ ⦄
+                ⦃ rcat : R.Category _⇨′_ ⦄
        : Set (suc o ⊔ ℓ ⊔ suc q) where
   private infix 0 _⇨_; _⇨_ = _⇨′_
   field
     identityˡ : {f : a ⇨ b} → id ∘ f ≈ f
     identityʳ : {f : a ⇨ b} → f ∘ id ≈ f
-    assoc     : {f : a ⇨ b} {g : b ⇨ c} {h : c ⇨ d}
-              → (h ∘ g) ∘ f ≈ h ∘ (g ∘ f)
+    assoc     : {f : a ⇨ b} {g : b ⇨ c} {h : c ⇨ d} → (h ∘ g) ∘ f ≈ h ∘ (g ∘ f)
 
+    -- TODO: infix?
     ∘≈ : ∀ {f g : a ⇨ b} {h k : b ⇨ c} → h ≈ k → f ≈ g → h ∘ f ≈ k ∘ g
+
+  -- TODO: replace the assoc field after I've inspected all uses
+  ∘-assocʳ : {f : a ⇨ b} {g : b ⇨ c} {h : c ⇨ d} → (h ∘ g) ∘ f ≈ h ∘ (g ∘ f)
+  ∘-assocʳ = assoc
+
+  ∘-assocˡ : {f : a ⇨ b} {g : b ⇨ c} {h : c ⇨ d} → h ∘ (g ∘ f) ≈ (h ∘ g) ∘ f
+  ∘-assocˡ = sym ∘-assocʳ
 
   ∘≈ˡ : ∀ {f : a ⇨ b} {h k : b ⇨ c} → h ≈ k → h ∘ f ≈ k ∘ f
   ∘≈ˡ h≈k = ∘≈ h≈k refl
@@ -79,10 +87,21 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
   field
     ⦃ ⇨Category ⦄ : Category _⇨_
 
-    ∀× : ∀ {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
-       → (k ≈ f ▵ g) ⇔ (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g)
+    ∀⊤ : ∀ {f : a ⇨ ⊤} → f ≈ !
 
+    ∀× : ∀ {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
+       → k ≈ f ▵ g ⇔ (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g)
+
+    -- TODO: infix?
     ▵≈ : ∀ {f g : a ⇨ c} {h k : a ⇨ d} → h ≈ k → f ≈ g → h ▵ f ≈ k ▵ g
+
+  ∀×→ : ∀ {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
+     → k ≈ f ▵ g → (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g)
+  ∀×→ = to ∀× ⟨$⟩_
+
+  ∀×← : ∀ {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
+     → (exl ∘ k ≈ f  ×ₚ  exr ∘ k ≈ g) → k ≈ f ▵ g
+  ∀×← = from ∀× ⟨$⟩_
 
   ▵≈ˡ : ∀ {f : a ⇨ c} {h k : a ⇨ d} → h ≈ k → h ▵ f ≈ k ▵ f
   ▵≈ˡ h≈k = ▵≈ h≈k refl
@@ -90,12 +109,44 @@ record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
   ▵≈ʳ : ∀ {f g : a ⇨ c} {h : a ⇨ d} → f ≈ g → h ▵ f ≈ h ▵ g
   ▵≈ʳ f≈g = ▵≈ refl f≈g
 
-  exl▵exr : ∀ {a b : obj} → exl ▵ exr ≈ id {a = a × b}
-  exl▵exr = sym (from ∀× ⟨$⟩ (identityʳ , identityʳ))
+  open import Data.Product using (proj₁; proj₂)
+  -- TODO: Generalize Function category from level 0, and use exl & exr in place
+  -- of proj₁ & proj₂
+
+  exl∘▵ : ∀ {f : a ⇨ b}{g : a ⇨ c} → exl ∘ (f ▵ g) ≈ f
+  exl∘▵ = proj₁ (∀×→ refl)
+
+  exr∘▵ : ∀ {f : a ⇨ b}{g : a ⇨ c} → exr ∘ (f ▵ g) ≈ g
+  exr∘▵ = proj₂ (∀×→ refl)
+
+  -- Specializing:
+  -- exl∘▵ : ∀ {f : a ⇨ c}{g : b ⇨ d} → exl ∘ (f ⊗ g) ≈ f ∘ exl
+  -- exr∘▵ : ∀ {f : a ⇨ c}{g : b ⇨ d} → exr ∘ (f ⊗ g) ≈ g ∘ exr
+
+  exl∘▵exr : ∀ {a b : obj} → exl ▵ exr ≈ id {a = a × b}
+  exl∘▵exr = sym (∀×← (identityʳ , identityʳ))
 
   id⊗id : ∀ {a b : obj} → id ⊗ id ≈ id {a = a × b}
-  id⊗id = exl▵exr • ▵≈ identityˡ identityˡ
+  id⊗id = exl∘▵exr • ▵≈ identityˡ identityˡ
 
+  ▵∘ : ∀ {f : a ⇨ b}{g : b ⇨ c}{h : b ⇨ d} → (g ▵ h) ∘ f ≈ g ∘ f ▵ h ∘ f
+  ▵∘ {f = f}{g}{h}= ∀×← (∘≈ˡ exl∘▵ • sym assoc , ∘≈ˡ exr∘▵ • sym assoc)
+  -- exl ∘ ((g ▵ h) ∘ f) ≈ g ∘ f
+
+  ⊗∘▵ : ∀ {f : a ⇨ b}{g : a ⇨ c}{h : b ⇨ d}{k : c ⇨ e}
+      → (h ⊗ k) ∘ (f ▵ g) ≈ h ∘ f ▵ k ∘ g
+  ⊗∘▵ {f = f}{g}{h}{k} =
+    begin
+      (h ⊗ k) ∘ (f ▵ g)
+    ≡⟨⟩
+      (h ∘ exl ▵ k ∘ exr) ∘ (f ▵ g)
+    ≈⟨ ▵∘ ⟩
+      (h ∘ exl) ∘ (f ▵ g) ▵ (k ∘ exr) ∘ (f ▵ g)
+    ≈⟨ ▵≈ assoc assoc ⟩
+      h ∘ exl ∘ (f ▵ g) ▵ k ∘ exr ∘ (f ▵ g)
+    ≈⟨ ▵≈ (∘≈ʳ exl∘▵) (∘≈ʳ exr∘▵) ⟩
+      h ∘ f ▵ k ∘ g
+    ∎
 
 open Cartesian ⦃ … ⦄ public
 
@@ -115,18 +166,25 @@ record CartesianClosed {obj : Set o} ⦃ _ : Products obj ⦄
 
     curry≈ : ∀ {f g : a × b ⇨ c} → f ≈ g → curry f ≈ curry g
 
+  ∀⇛→ : ∀ {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)}
+      → g ≈ curry f → f ≈ uncurry g
+  ∀⇛→ = to ∀⇛ ⟨$⟩_
+
+  ∀⇛← : ∀ {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)}
+      → f ≈ uncurry g → g ≈ curry f
+  ∀⇛← = from ∀⇛ ⟨$⟩_
+
   curry-apply : ∀ {a b : obj} → id { a = a ⇛ b } ≈ curry apply
-  curry-apply = from ∀⇛ ⟨$⟩
-                  (begin
-                     apply
-                   ≈˘⟨ identityʳ ⟩
-                     apply ∘ id
-                   ≈˘⟨ ∘≈ʳ id⊗id ⟩
-                     apply ∘ (id ⊗ id)
-                   ≡⟨⟩
-                     apply ∘ first id
-                   ≡⟨⟩
-                     uncurry id
-                   ∎)
+  curry-apply = ∀⇛← (begin
+                       apply
+                     ≈˘⟨ identityʳ ⟩
+                       apply ∘ id
+                     ≈˘⟨ ∘≈ʳ id⊗id ⟩
+                       apply ∘ (id ⊗ id)
+                     ≡⟨⟩
+                       apply ∘ first id
+                     ≡⟨⟩
+                       uncurry id
+                     ∎)
 
 -- TODO: Logic

--- a/Everything.agda
+++ b/Everything.agda
@@ -9,6 +9,7 @@ import Categorical.Laws
 
 -- import Categorical.Comma
 import Categorical.Comma.Type
+import Categorical.Arrow
 
 import Functions
 import Ty

--- a/Functions/Laws.agda
+++ b/Functions/Laws.agda
@@ -33,7 +33,8 @@ module →-laws-instances where
 
     cartesian : Cartesian Function
     cartesian = record
-      { ∀× = equivalence
+      { ∀⊤ = λ _ → refl≡
+      ; ∀× = equivalence
           (λ k≈f▵g → (λ x → cong exl (k≈f▵g x)) , (λ x → cong exr (k≈f▵g x)))
           (λ (exl∘k≈f , exr∘k≈g) x → cong₂ _,_ (exl∘k≈f x) (exr∘k≈g x))
       ; ▵≈ = λ h≈k f≈g x → cong₂ _,_ (h≈k x) (f≈g x)

--- a/Ty.agda
+++ b/Ty.agda
@@ -43,7 +43,11 @@ module ty-instances where
                   {_⇨_ : obj → obj → Set ℓ} ⦃ _ : Category _⇨_ ⦄
                   {q} ⦃ _ : Equivalent q _⇨_ ⦄ ⦃ _ : L.Category _⇨_ ⦄
              → ProductsH Ty _⇨_
-    productsH = record { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id ; ε⁻¹∘ε = L.identityˡ }
+    productsH = record
+      { ε = id ; μ = id ; ε⁻¹ = id ; μ⁻¹ = id
+      ; ε⁻¹∘ε = L.identityˡ ; ε∘ε⁻¹ = L.identityˡ
+      ; μ⁻¹∘μ = L.identityˡ ; μ∘μ⁻¹ = L.identityˡ
+      }
 
     exponentialsH : ∀ {ℓ o}{obj : Set o} ⦃ _ : Products obj ⦄
                     ⦃ _ : Boolean obj ⦄ ⦃ _ : Exponentials obj ⦄
@@ -55,7 +59,7 @@ module ty-instances where
                ⦃ _ : Boolean obj ⦄ ⦃ _ : Exponentials obj ⦄
                {_⇨_ : obj → obj → Set ℓ} ⦃ _ : Category _⇨_ ⦄
              → BooleanH Ty _⇨_
-    booleanH = record { β = id }
+    booleanH = record { β = id ; β⁻¹ = id }
 
 
 open import Data.Nat


### PR DESCRIPTION
This PR adds a `Cartesian` instance to the `Category` instance for the “comma” construction. The combination provides sequential and parallel composition of correctness proofs (commutative squares just like Sean showed today) as well as of the (“specification” and “implementation”) morphisms being related.

These proofs really slow down type checking, so that this one module took more than two hours on my M1 MacBook Pro. My machine has only 8GB RAM. Perhaps 16GB would help, though I’ve heard that the M1 machine SSDs and connection to the M1 chip implement virtual memory quite efficiently. (Costco doesn’t carry the 16GB version, and I like their extended return period and warranty.)

I was starting to see this sort of dramatic slow-down in the old repo (agda-machines), so in the current repo, I’ve put proofs in `*.Laws` modules, hoping that they will rarely need to be loaded. I’ve seen a similar practice in agda-stdlib and agda-categories, with `Properties` modules.

For the comma construction, however, the proofs are an integral part of the what the categorical operations *are*, not just that these operations themselves satisfy the usual laws. Thus, we cannot compile & load the functionality without the commutativity proofs. Ironically, for comma categories, the category and cartesian (and hopefully closed cartesian) laws will be trivial to prove, because they follow trivial, forgetful homomorphisms.

After merging, I’ll ask the Agda Zulip wizards for help.
