### PR TITLE
 Move Category and Cartesian instance fields to instance parameters

### DIFF
--- a/Categorical/Arrow.agda
+++ b/Categorical/Arrow.agda
@@ -9,9 +9,9 @@ open import Categorical.Laws as L hiding (Category; Cartesian)
 open import Categorical.Homomorphism
 
 module Categorical.Arrow
-   {o}{obj : Set o} ⦃ _ : Products obj ⦄
-   {ℓ} (_↠_ : obj → obj → Set ℓ) ⦃ _ : Category _↠_ ⦄ ⦃ _ : Cartesian _↠_ ⦄
-   {q} ⦃ _ : Equivalent q _↠_ ⦄ ⦃ _ : L.Category _↠_ ⦄ ⦃ _ : L.Cartesian _↠_ ⦄
+   {o}{obj : Set o}
+   {ℓ} (_↠_ : obj → obj → Set ℓ) ⦃ _ : Category _↠_ ⦄
+   {q} ⦃ _ : Equivalent q _↠_ ⦄ ⦃ _ : L.Category _↠_ ⦄
  where
 
 private
@@ -26,20 +26,22 @@ private
     catH : CategoryH _↠_ _↠_
     catH = id-CategoryH
 
+    -- TODO: Replace Hₒ, H, etc by a bundle
+
+open import Categorical.Comma.Raw _↠_ _↠_ _↠_
+              ⦃ catH₁ = catH ⦄ ⦃ catH₂ = catH ⦄ public
+
+
+module arrow-products ⦃ p : Products obj ⦄ ⦃ c : Cartesian _↠_ ⦄ ⦃ lc : L.Cartesian _↠_ ⦄ where
+
+  instance
+
     prodH : ProductsH obj _↠_
     prodH = id-ProductsH
 
     cartH : CartesianH _↠_ _↠_
     cartH = id-CartesianH
 
-    -- TODO: Replace Hₒ, H, etc by a bundle
-
--- open import Categorical.Comma.Type _↠_ _↠_ _↠_ ⦃ ch₁ = catH ⦄ ⦃ ch₂ = catH ⦄ public
-
-open import Categorical.Comma.Raw _↠_ _↠_ _↠_
-  ⦃ catH₁ = catH ⦄ ⦃ cartH₁ = cartH ⦄
-  ⦃ catH₂ = catH ⦄ ⦃ cartH₂ = cartH ⦄
-  public
 
 -- Transposition
 _ᵀ : ∀ {a b} ((mk f₁ f₂ _) : a ⇨ b) → (f₁ ⇉ f₂)

--- a/Categorical/Arrow.agda
+++ b/Categorical/Arrow.agda
@@ -10,8 +10,8 @@ open import Categorical.Homomorphism
 
 module Categorical.Arrow
    {o}{obj : Set o} ⦃ _ : Products obj ⦄
-   {ℓ} (_↠_ : obj → obj → Set ℓ) ⦃ _ : Cartesian _↠_ ⦄
-   {q} ⦃ _ : Equivalent q _↠_ ⦄ ⦃ _ : L.Cartesian _↠_ ⦄
+   {ℓ} (_↠_ : obj → obj → Set ℓ) ⦃ _ : Category _↠_ ⦄ ⦃ _ : Cartesian _↠_ ⦄
+   {q} ⦃ _ : Equivalent q _↠_ ⦄ ⦃ _ : L.Category _↠_ ⦄ ⦃ _ : L.Cartesian _↠_ ⦄
  where
 
 private

--- a/Categorical/Comma.agda
+++ b/Categorical/Comma.agda
@@ -9,14 +9,14 @@ open import Categorical.Homomorphism
 
 module Categorical.Comma
    {o₁}{obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄
-     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Cartesian _⇨₁_ ⦄
+     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
    {o₂}{obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
-     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Cartesian _⇨₂_ ⦄
+     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
    {o₃}{obj₃ : Set o₃} ⦃ _ : Products obj₃ ⦄
-     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Cartesian _⇨₃_ ⦄
-   {q} ⦃ _ : Equivalent q _⇨₁_ ⦄ ⦃ _ : L.Cartesian _⇨₁_ ⦄
-       ⦃ _ : Equivalent q _⇨₂_ ⦄ ⦃ _ : L.Cartesian _⇨₂_ ⦄
-       ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
+     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄ ⦃ _ : Cartesian _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₁_ ⦄ ⦃ _ : L.Category _⇨₁_ ⦄ ⦃ _ : L.Cartesian _⇨₁_ ⦄
+       ⦃ _ : Equivalent q _⇨₂_ ⦄ ⦃ _ : L.Category _⇨₂_ ⦄ ⦃ _ : L.Cartesian _⇨₂_ ⦄
+       ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₃_ ⦄
      ⦃ _ : CategoryH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄
      ⦃ _ : CartesianH _⇨₁_ _⇨₃_ ⦄
@@ -24,6 +24,8 @@ module Categorical.Comma
      ⦃ _ : CategoryH _⇨₂_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
      ⦃ _ : CartesianH _⇨₂_ _⇨₃_ ⦄
  where
+
+-- TODO: Move Cartesian from module parameters to Cartesian instance
 
 -- Comma.Type and Comma.Raw are re-exported by Comma.Homomorphism
 open import Categorical.Comma.Homomorphism _⇨₁_ _⇨₂_ _⇨₃_ public

--- a/Categorical/Comma/Homomorphism.agda
+++ b/Categorical/Comma/Homomorphism.agda
@@ -8,24 +8,20 @@ open import Categorical.Laws as L hiding (Category; Cartesian)
 open import Categorical.Homomorphism
 
 module Categorical.Comma.Homomorphism
-   {o₁}{obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄
-     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
-   {o₂}{obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
-     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
-   {o₃}{obj₃ : Set o₃} ⦃ _ : Products obj₃ ⦄
-     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄ ⦃ _ : Cartesian _⇨₃_ ⦄
-   {q} ⦃ _ : Equivalent q _⇨₁_ ⦄ ⦃ _ : L.Category _⇨₁_ ⦄ ⦃ _ : L.Cartesian _⇨₁_ ⦄
-       ⦃ _ : Equivalent q _⇨₂_ ⦄ ⦃ _ : L.Category _⇨₂_ ⦄ ⦃ _ : L.Cartesian _⇨₂_ ⦄
-       ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
+   {o₁}{obj₁ : Set o₁}
+     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄
+   {o₂}{obj₂ : Set o₂}
+     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄
+   {o₃}{obj₃ : Set o₃}
+     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₁_ ⦄ ⦃ _ : L.Category _⇨₁_ ⦄
+       ⦃ _ : Equivalent q _⇨₂_ ⦄ ⦃ _ : L.Category _⇨₂_ ⦄
+       ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₃_ ⦄
-     ⦃ _ : CategoryH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄
-     ⦃ _ : CartesianH _⇨₁_ _⇨₃_ ⦄
+     ⦃ catH₁ : CategoryH _⇨₁_ _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₂ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₂_ _⇨₃_ ⦄
-     ⦃ _ : CategoryH _⇨₂_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
-     ⦃ _ : CartesianH _⇨₂_ _⇨₃_ ⦄
+     ⦃ catH₂ : CategoryH _⇨₂_ _⇨₃_ ⦄
  where
-
--- TODO: Move Cartesian from module parameters to Cartesian instance
 
 open import Categorical.Comma.Raw _⇨₁_ _⇨₂_ _⇨₃_ public
 

--- a/Categorical/Comma/Homomorphism.agda
+++ b/Categorical/Comma/Homomorphism.agda
@@ -9,14 +9,14 @@ open import Categorical.Homomorphism
 
 module Categorical.Comma.Homomorphism
    {o₁}{obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄
-     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Cartesian _⇨₁_ ⦄
+     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
    {o₂}{obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
-     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Cartesian _⇨₂_ ⦄
+     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
    {o₃}{obj₃ : Set o₃} ⦃ _ : Products obj₃ ⦄
-     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Cartesian _⇨₃_ ⦄
-   {q} ⦃ _ : Equivalent q _⇨₁_ ⦄ ⦃ _ : L.Cartesian _⇨₁_ ⦄
-       ⦃ _ : Equivalent q _⇨₂_ ⦄ ⦃ _ : L.Cartesian _⇨₂_ ⦄
-       ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
+     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄ ⦃ _ : Cartesian _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₁_ ⦄ ⦃ _ : L.Category _⇨₁_ ⦄ ⦃ _ : L.Cartesian _⇨₁_ ⦄
+       ⦃ _ : Equivalent q _⇨₂_ ⦄ ⦃ _ : L.Category _⇨₂_ ⦄ ⦃ _ : L.Cartesian _⇨₂_ ⦄
+       ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₃_ ⦄
      ⦃ _ : CategoryH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄
      ⦃ _ : CartesianH _⇨₁_ _⇨₃_ ⦄
@@ -24,6 +24,8 @@ module Categorical.Comma.Homomorphism
      ⦃ _ : CategoryH _⇨₂_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
      ⦃ _ : CartesianH _⇨₂_ _⇨₃_ ⦄
  where
+
+-- TODO: Move Cartesian from module parameters to Cartesian instance
 
 open import Categorical.Comma.Raw _⇨₁_ _⇨₂_ _⇨₃_ public
 

--- a/Categorical/Comma/Raw.agda
+++ b/Categorical/Comma/Raw.agda
@@ -11,12 +11,12 @@ open import Categorical.Reasoning
 
 module Categorical.Comma.Raw
    {o₁}{obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄
-     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Cartesian _⇨₁_ ⦄
+     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
    {o₂}{obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
-     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Cartesian _⇨₂_ ⦄
+     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
    {o₃}{obj₃ : Set o₃} ⦃ _ : Products obj₃ ⦄
-     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Cartesian _⇨₃_ ⦄
-   {q} ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
+     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄ ⦃ _ : Cartesian _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₃_ ⦄
      ⦃ catH₁ : CategoryH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄
      ⦃ cartH₁ : CartesianH _⇨₁_ _⇨₃_ ⦄
@@ -24,6 +24,8 @@ module Categorical.Comma.Raw
      ⦃ catH₂ : CategoryH _⇨₂_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
      ⦃ cartH₂ : CartesianH _⇨₂_ _⇨₃_ ⦄
  where
+
+-- TODO: Move Cartesian from module parameters to Cartesian instance
 
 open import Categorical.Comma.Type _⇨₁_ _⇨₂_ _⇨₃_
        ⦃ catH₁ = catH₁ ⦄ ⦃ catH₂ = catH₂ ⦄

--- a/Categorical/Comma/Raw.agda
+++ b/Categorical/Comma/Raw.agda
@@ -10,22 +10,18 @@ open ≈-Reasoning
 open import Categorical.Reasoning
 
 module Categorical.Comma.Raw
-   {o₁}{obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄
-     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
-   {o₂}{obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄
-     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
-   {o₃}{obj₃ : Set o₃} ⦃ _ : Products obj₃ ⦄
-     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄ ⦃ _ : Cartesian _⇨₃_ ⦄
-   {q} ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄ ⦃ _ : L.Cartesian _⇨₃_ ⦄
+   {o₁}{obj₁ : Set o₁}
+     {ℓ₁} (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁) ⦃ _ : Category _⇨₁_ ⦄
+   {o₂}{obj₂ : Set o₂}
+     {ℓ₂} (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂) ⦃ _ : Category _⇨₂_ ⦄
+   {o₃}{obj₃ : Set o₃}
+     {ℓ₃} (_⇨₃_ : obj₃ → obj₃ → Set ℓ₃) ⦃ _ : Category _⇨₃_ ⦄
+   {q} ⦃ _ : Equivalent q _⇨₃_ ⦄ ⦃ _ : L.Category _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₁ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₁_ _⇨₃_ ⦄
-     ⦃ catH₁ : CategoryH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄
-     ⦃ cartH₁ : CartesianH _⇨₁_ _⇨₃_ ⦄
+     ⦃ catH₁ : CategoryH _⇨₁_ _⇨₃_ ⦄
    ⦃ _ : Homomorphismₒ obj₂ obj₃ ⦄ ⦃ _ : Homomorphism _⇨₂_ _⇨₃_ ⦄
-     ⦃ catH₂ : CategoryH _⇨₂_ _⇨₃_ ⦄ ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
-     ⦃ cartH₂ : CartesianH _⇨₂_ _⇨₃_ ⦄
+     ⦃ catH₂ : CategoryH _⇨₂_ _⇨₃_ ⦄
  where
-
--- TODO: Move Cartesian from module parameters to Cartesian instance
 
 open import Categorical.Comma.Type _⇨₁_ _⇨₂_ _⇨₃_
        ⦃ catH₁ = catH₁ ⦄ ⦃ catH₂ = catH₂ ⦄
@@ -33,7 +29,7 @@ open import Categorical.Comma.Type _⇨₁_ _⇨₂_ _⇨₃_
 
 open Obj
 
-private
+module comma-cat where
 
   -- variable a : Obj  --  "No instance of type CategoryH _⇨₂_ _⇨₃_ was found in scope."
 
@@ -72,7 +68,18 @@ private
     mk (g₁ ∘ f₁) (g₂ ∘ f₂)
        (∘≈ʳ F-∘ ; ∘-assocˡ′ comm-g ; ∘-assocʳ′ comm-f ; ∘-assocˡ′ (sym F-∘))
 
-module comma-raw-instances-obj where
+  instance
+
+    category : Category _⇨_
+    category = record { id = id′ ; _∘_ = comp }
+
+module comma-products
+    ⦃ _ : Products obj₁ ⦄  ⦃ _ : Products obj₂ ⦄  ⦃ _ : Products obj₃ ⦄
+    ⦃ _ : Cartesian _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₃_ ⦄
+    ⦃ _ : L.Cartesian _⇨₃_ ⦄
+    ⦃ _ : ProductsH obj₁ _⇨₃_ ⦄  ⦃ _ : ProductsH obj₂ _⇨₃_ ⦄
+    ⦃ _ : CartesianH _⇨₁_ _⇨₃_ ⦄ ⦃ _ : CartesianH _⇨₂_ _⇨₃_ ⦄
+  where
 
   instance
 
@@ -80,8 +87,6 @@ module comma-raw-instances-obj where
     products = record { ⊤   = mk (ε ∘ ε⁻¹)
                       ; _×_ = λ (mk h) (mk k) → mk (μ ∘ (h ⊗ k) ∘ μ⁻¹)
                       }
-
-private
 
   -- !′ : ∀ {a} → a ⇨ ⊤
   -- !′ {a} = mk ! !
@@ -164,15 +169,10 @@ private
     ; sym (∘-assocˡ′ F-exr)
     )
 
-
-module comma-raw-instances where
-
   instance
 
-    category : Category _⇨_
-    category = record { id = id′ ; _∘_ = comp }
-  
     cartesian : Cartesian _⇨_
     cartesian = record { ! = !′ ; _▵_ = fork ; exl = exl′ ; exr = exr′ }
 
-    -- TODO: CartesianClosed and Logic.
+-- TODO: CartesianClosed and Logic.
+

--- a/Categorical/Homomorphism.agda
+++ b/Categorical/Homomorphism.agda
@@ -86,8 +86,8 @@ record CartesianH
          {obj₁ : Set o₁} ⦃ _ : Products obj₁ ⦄ (_⇨₁_ : obj₁ → obj₁ → Set ℓ₁)
          {obj₂ : Set o₂} ⦃ _ : Products obj₂ ⦄ (_⇨₂_ : obj₂ → obj₂ → Set ℓ₂)
          {q} ⦃ _ : Equivalent q _⇨₂_ ⦄
-         ⦃ _ : Cartesian _⇨₁_ ⦄
-         ⦃ _ : Cartesian _⇨₂_ ⦄
+         ⦃ _ : Category _⇨₁_ ⦄ ⦃ _ : Cartesian _⇨₁_ ⦄
+         ⦃ _ : Category _⇨₂_ ⦄ ⦃ _ : Cartesian _⇨₂_ ⦄
          ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
          ⦃ H : Homomorphism _⇨₁_ _⇨₂_ ⦄
          ⦃ pH : ProductsH obj₁ _⇨₂_ ⦄
@@ -116,8 +116,8 @@ open CartesianH ⦃ … ⦄ public
 
 id-CartesianH : {obj : Set o} {_⇨_ : obj → obj → Set ℓ} ⦃ _ : Products obj ⦄
                 {q : Level} ⦃ _ : Equivalent q _⇨_ ⦄
-                ⦃ _ : Cartesian _⇨_ ⦄
-                ⦃ _ : L.Cartesian _⇨_ ⦄
+                ⦃ _ :   Category _⇨_ ⦄ ⦃ _ :   Cartesian _⇨_ ⦄
+                ⦃ _ : L.Category _⇨_ ⦄ ⦃ _ : L.Cartesian _⇨_ ⦄
               → CartesianH _⇨_ _⇨_ ⦃ Hₒ = id-Hₒ ⦄ ⦃ H = id-H ⦄ ⦃ pH = id-ProductsH ⦄
 id-CartesianH = record
   { F-!   = sym identityˡ
@@ -181,7 +181,7 @@ record LogicH
     {q} ⦃ _ : Equivalent q _⇨₂′_ ⦄
     ⦃ _ : Boolean obj₁ ⦄ ⦃ _ : Products obj₁ ⦄ ⦃ _ : Logic _⇨₁′_ ⦄
     ⦃ _ : Boolean obj₂ ⦄ ⦃ _ : Products obj₂ ⦄ ⦃ _ : Logic _⇨₂′_ ⦄
-    ⦃ _ : Cartesian _⇨₂′_ ⦄
+    ⦃ _ : Category _⇨₂′_ ⦄ ⦃ _ : Cartesian _⇨₂′_ ⦄
     ⦃ Hₒ : Homomorphismₒ obj₁ obj₂ ⦄
     ⦃ H : Homomorphism _⇨₁′_ _⇨₂′_ ⦄
     ⦃ productsH : ProductsH obj₁ _⇨₂′_ ⦄

--- a/Categorical/Laws.agda
+++ b/Categorical/Laws.agda
@@ -80,13 +80,12 @@ open import Data.Product using (_,_) renaming (_×_ to _×ₚ_)
 record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
                  (_⇨′_ : obj → obj → Set ℓ)
                  {q} ⦃ _ : Equivalent q _⇨′_ ⦄
-                 ⦃ _ : R.Cartesian _⇨′_ ⦄
+                 ⦃ _ : R.Category _⇨′_ ⦄ ⦃ _ : R.Cartesian _⇨′_ ⦄
+                 ⦃ ⇨Category : Category _⇨′_ ⦄
        : Set (suc o ⊔ ℓ ⊔ suc q) where
   private infix 0 _⇨_; _⇨_ = _⇨′_
 
   field
-    ⦃ ⇨Category ⦄ : Category _⇨_
-
     ∀⊤ : ∀ {f : a ⇨ ⊤} → f ≈ !
 
     ∀× : ∀ {f : a ⇨ b} {g : a ⇨ c} {k : a ⇨ b × c}
@@ -154,12 +153,13 @@ record CartesianClosed {obj : Set o} ⦃ _ : Products obj ⦄
                        ⦃ _ : Exponentials obj ⦄ (_⇨′_ : obj → obj → Set ℓ)
                        {q} ⦃ _ : Equivalent q _⇨′_ ⦄
                        ⦃ _ : Products (Set q) ⦄
+                       ⦃ _ : R.Category _⇨′_ ⦄
+                       ⦃ _ : R.Cartesian _⇨′_ ⦄
                        ⦃ _ : R.CartesianClosed _⇨′_ ⦄
+                       ⦃ ⇨Category : Category _⇨′_ ⦄ ⦃ ⇨Cartesian : Cartesian _⇨′_ ⦄
        : Set (suc o ⊔ ℓ ⊔ suc q) where
   private infix 0 _⇨_; _⇨_ = _⇨′_
   field
-    ⦃ ⇨Cartesian ⦄ : Cartesian _⇨_
-
     ∀⇛ : ∀ {f : a × b ⇨ c} {g : a ⇨ (b ⇛ c)} → (g ≈ curry f) ⇔ (f ≈ uncurry g)
     -- Note: uncurry g ≡ apply ∘ first g ≡ apply ∘ (g ⊗ id)
     -- RHS is often written "apply ∘ (g ⊗ id)"

--- a/Categorical/Raw.agda
+++ b/Categorical/Raw.agda
@@ -24,13 +24,14 @@ open Category ⦃ … ⦄ public
 
 
 record Cartesian {obj : Set o} ⦃ _ : Products obj ⦄
-         (_⇨′_ : obj → obj → Set ℓ) : Set (o ⊔ ℓ) where
+         (_⇨′_ : obj → obj → Set ℓ)
+         ⦃ ⇨Category : Category _⇨′_ ⦄
+    : Set (o ⊔ ℓ) where
   private infix 0 _⇨_; _⇨_ = _⇨′_
   infixr 7 _▵_
   field
-    ⦃ ⇨Category ⦄ : Category _⇨_
     !   : a ⇨ ⊤
-    _▵_ : ∀ {a c d} → (a ⇨ c) → (a ⇨ d) → (a ⇨ c × d)
+    _▵_ : (a ⇨ c) → (a ⇨ d) → (a ⇨ c × d)
     exl : a × b ⇨ a
     exr : a × b ⇨ b
 
@@ -126,10 +127,13 @@ open Cartesian ⦃ … ⦄ public
 
 record CartesianClosed {obj : Set o}
          ⦃ _ : Products obj ⦄ ⦃ _ : Exponentials obj ⦄
-         (_⇨′_ : obj → obj → Set ℓ) : Set (o ⊔ ℓ) where
+         (_⇨′_ : obj → obj → Set ℓ)
+         ⦃ ⇨Category : Category _⇨′_ ⦄
+         ⦃ ⇨Cartesian : Cartesian _⇨′_ ⦄
+    : Set (o ⊔ ℓ) where
   private infix 0 _⇨_; _⇨_ = _⇨′_
   field
-    ⦃ ⇨Cartesian ⦄ : Cartesian _⇨_
+    
     curry : (a × b ⇨ c) → (a ⇨ (b ⇛ c))
     apply : (a ⇛ b) × a ⇨ b
 

--- a/Examples/Add.agda
+++ b/Examples/Add.agda
@@ -8,7 +8,7 @@ open import Functions.Raw
 module Examples.Add
          {o} {obj : Set o} ⦃ _ : Products obj ⦄ ⦃ _ : Boolean obj ⦄
          {_⇨_ : obj → obj → Set} (let private infix 0 _⇨_; _⇨_ = _⇨_)
-         ⦃ _ : Cartesian _⇨_ ⦄ ⦃ _ : Logic _⇨_ ⦄
+         ⦃ _ : Category _⇨_ ⦄ ⦃ _ : Cartesian _⇨_ ⦄ ⦃ _ : Logic _⇨_ ⦄
  where
 
 -- TODO: package up module parameters into one record to pass in and open.

--- a/Linearize/Raw.agda
+++ b/Linearize/Raw.agda
@@ -7,8 +7,9 @@ module Linearize.Raw {o}{objₘ : Set o} ⦃ _ : Products objₘ ⦄ ⦃ _ : Exp
              {ℓ}{obj : Set ℓ} ⦃ _ : Products obj ⦄ ⦃ _ : Exponentials obj ⦄
              (_⇨ₚ_ : obj → obj → Set ℓ) (let infix 0 _⇨ₚ_; _⇨ₚ_ = _⇨ₚ_)
              (_⇨ᵣ_ : obj → obj → Set ℓ) (let infix 0 _⇨ᵣ_; _⇨ᵣ_ = _⇨ᵣ_)
-             ⦃ _ : CartesianClosed _⇨ₘ_ ⦄   -- monoidal suffices?
-             ⦃ _ : Cartesian _⇨ᵣ_ ⦄   -- braided suffices
+             ⦃ _ : Category _⇨ₘ_ ⦄ ⦃ _ : Cartesian _⇨ₘ_ ⦄
+               ⦃ _ : CartesianClosed _⇨ₘ_ ⦄   -- monoidal suffices?
+             ⦃ _ : Category _⇨ᵣ_ ⦄ ⦃ _ : Cartesian _⇨ᵣ_ ⦄  -- braided suffices?
              -- The rest are for ⟦_⟧ₖ. Maybe move them into a submodule.
              ⦃ Hₒ : Homomorphismₒ obj objₘ ⦄
              ⦃ Hₚ : Homomorphism _⇨ₚ_ _⇨ₘ_ ⦄

--- a/Ty/Utils.agda
+++ b/Ty/Utils.agda
@@ -6,7 +6,7 @@ open import Ty
 
 module Ty.Utils {ℓ}
   {_⇨_ : Ty → Ty → Set ℓ} (let infix 0 _⇨_; _⇨_ = _⇨_)
-  ⦃ _ : Cartesian _⇨_ ⦄
+  ⦃ _ : Category _⇨_ ⦄ ⦃ _ : Cartesian _⇨_ ⦄
   where
 
 open import Data.Nat


### PR DESCRIPTION
Allows some needed flexibility. For instance `Categorical.Comma.Raw` depends on `Category` at the module level and on `Cartesian` for some instances. If `Cartesian` contained `Category`, then there would be two paths to `Category`, breaking automatic instance resolution.
