### PR TITLE
Vector categories

### DIFF
--- a/Functions/Laws.agda
+++ b/Functions/Laws.agda
@@ -3,12 +3,12 @@
 module Functions.Laws where
 
 open import Function.Equivalence hiding (id; _∘_)
+open import Axiom.Extensionality.Propositional
 
 open import Categorical.Raw hiding (Category; Cartesian; CartesianClosed)
 open import Categorical.Laws
 open import Categorical.Equiv
 open import Functions.Raw public
-open import Axiom.Extensionality.Propositional
 
 module →-laws-instances where
 

--- a/VRouting/Homomorphism.agda
+++ b/VRouting/Homomorphism.agda
@@ -1,0 +1,118 @@
+{-# OPTIONS --safe --without-K #-}
+
+open import Data.Product using (_,_)
+open import Relation.Binary.PropositionalEquality renaming (refl to refl≡)
+
+module VRouting.Homomorphism {A : Set} where
+
+open import Data.Nat
+open import Data.Fin hiding (_+_)
+open import Data.Vec
+open import Data.Vec.Properties
+
+open import Function using (_∘′_) -- TEMP
+
+open import Functions.Raw
+open import Functions.Laws
+open import Vector.Laws {A} renaming (_⇨_ to _↠_)
+open import VRouting.Raw {A} public ; open _⇨_
+
+open import Categorical.Laws
+open import Categorical.Homomorphism
+
+open ≡-Reasoning
+
+private
+
+  swizzle-allFin : {a : ℕ} → swizzle (allFin a) ≈ id
+  swizzle-allFin = map-lookup-allFin
+
+  swizzle-map-lookup : {a b c : ℕ}(g : Swizzle b c)(f : Swizzle a b)
+                     → swizzle (map (lookup f) g) ≈ swizzle g ∘ swizzle f
+  swizzle-map-lookup g f xs =
+    begin
+      swizzle (map (lookup f) g) xs
+    ≡⟨⟩
+      map (lookup xs) (map (lookup f) g)
+    ≡˘⟨ map-∘ (lookup xs) (lookup f) g ⟩
+      map (lookup xs ∘ lookup f) g
+    ≡˘⟨ map-cong (λ i → lookup-map i (lookup xs) f) g ⟩
+      map (lookup (map (lookup xs) f)) g
+    ≡⟨⟩
+      (swizzle g ∘ swizzle f) xs
+    ∎
+
+  swizzle-tabulate-inject+ : ∀ {m n} → swizzle (tabulate (inject+ n)) ≈ take m
+  swizzle-tabulate-inject+ {m}{n} xs =
+    begin
+      swizzle (tabulate (inject+ n)) xs
+    ≡⟨⟩
+      map (lookup xs) (tabulate (inject+ n))
+    ≡˘⟨ tabulate-∘ (lookup xs) (inject+ n) ⟩
+      tabulate (lookup xs ∘ inject+ n)
+    ≡˘⟨ cong (λ z → tabulate (lookup z ∘ inject+ n)) (take-drop-id m xs) ⟩
+      tabulate (lookup (take m xs ++ drop m xs) ∘ inject+ n)
+    ≡⟨ tabulate-cong (lookup-++ˡ (take m xs) (drop m xs)) ⟩
+      tabulate (lookup (take m xs))
+    ≡⟨ tabulate∘lookup _ ⟩
+      take m xs
+    ∎
+
+  swizzle-tabulate-raise : ∀ {m n} → swizzle (tabulate (raise {n} m)) ≈ drop m
+  swizzle-tabulate-raise {m}{n} xs =
+    begin
+      swizzle (tabulate (raise m)) xs
+    ≡⟨⟩
+      map (lookup xs) (tabulate (raise m))
+    ≡˘⟨ tabulate-∘ (lookup xs) (raise m) ⟩
+      tabulate (lookup xs ∘ raise m)
+    ≡˘⟨ cong (λ z → tabulate (lookup z ∘ raise m)) (take-drop-id m xs) ⟩
+      tabulate (lookup (take m xs ++ drop m xs) ∘ raise m)
+    ≡⟨ tabulate-cong (lookup-++ʳ (take m xs) (drop m xs)) ⟩
+      tabulate (lookup (drop m xs))
+    ≡⟨ tabulate∘lookup _ ⟩
+      drop m xs
+    ∎
+
+  -- Oddly, I didn't find this lemma in agda-stdlib
+  map-++ : ∀ {ℓ}{A B : Set ℓ}(f : A → B){m n}(u : Vec A m)(v : Vec A n)
+         → map f (u ++ v) ≡ map f u ++ map f v
+  map-++ f [] v = refl≡
+  map-++ f (x ∷ u) v = cong (f x ∷_) (map-++ f u v)
+
+  swizzle-++ : ∀ {a c d} (f : Swizzle a c)(g : Swizzle a d)
+             → swizzle (f ++ g) ≈ uncurry _++_ ∘ (swizzle f ▵ swizzle g)
+  swizzle-++ f g xs =
+    begin
+      swizzle (f ++ g) xs
+    ≡⟨⟩
+      map (lookup xs) (f ++ g)
+    ≡⟨ map-++ (lookup xs) f g ⟩
+      map (lookup xs) f ++ map (lookup xs) g
+    ≡⟨⟩
+      swizzle f xs ++ swizzle g xs
+    ≡⟨⟩
+      (uncurry _++_ ∘ (swizzle f ▵ swizzle g)) xs
+    ∎
+
+module vrouting-homomorphism-instances where
+
+  instance
+
+    categoryH : CategoryH _⇨_ _↠_
+    categoryH = record
+      { F-id = swizzle-allFin
+      ; F-∘  = λ { {g = mk g} {mk f} → swizzle-map-lookup g f }
+      }
+
+    pH : ProductsH ℕ _↠_
+    pH = id-ProductsH
+
+    cartesianH : CartesianH _⇨_ _↠_
+    cartesianH = record
+      { F-!   = λ _ → refl≡
+      ; F-exl = swizzle-tabulate-inject+
+      ; F-exr = swizzle-tabulate-raise
+      ; F-▵   = λ {a c d}{(mk f) (mk g)} → swizzle-++ f g
+      }
+

--- a/VRouting/Laws.agda
+++ b/VRouting/Laws.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --safe --without-K #-}
+
+module VRouting.Laws {A : Set} where
+
+open import Categorical.Raw
+import Categorical.Laws as L
+open import Categorical.MakeLawful
+
+open import Vector.Laws {A} renaming (_⇨_ to _↠_)
+open import VRouting.Homomorphism {A} public
+
+-- Inherit lawfulness from vector functions
+
+module vrouting-laws-instances where
+
+  instance
+
+    category : L.Category _⇨_
+    category = LawfulCategoryᶠ _↠_

--- a/VRouting/Raw.agda
+++ b/VRouting/Raw.agda
@@ -1,0 +1,35 @@
+{-# OPTIONS --safe --without-K #-}
+
+module VRouting.Raw {A : Set} where
+
+open import Data.Nat
+open import Data.Fin hiding (_+_)
+open import Data.Vec
+open import Function using (case_of_)
+
+open import Data.Sum using ([_,_])
+
+open import Categorical.Raw
+open import Functions.Raw
+
+open import Vector.Raw {A} hiding (_⇨_)
+
+open import VRouting.Type {A} public
+
+module vrouting-raw-instances where
+
+  instance
+
+    category : Category _⇨_
+    category = record
+      { id  = mk (allFin _)
+      ; _∘_ = λ (mk g) (mk f) → mk (map (lookup f) g)
+      }
+
+    cartesian : Cartesian _⇨_
+    cartesian = record
+      { !   = mk []
+      ; _▵_ = λ (mk f) (mk g) → mk (f ++ g)
+      ; exl = mk (tabulate (inject+ _))
+      ; exr = mk (tabulate ( raise  _))
+      }

--- a/VRouting/Type.agda
+++ b/VRouting/Type.agda
@@ -1,0 +1,41 @@
+{-# OPTIONS --safe --without-K #-}
+
+module VRouting.Type {A : Set} where
+
+open import Data.Nat
+open import Data.Fin
+open import Data.Vec
+
+open import Categorical.Raw
+open import Categorical.Equiv
+open import Functions.Raw
+open import Vector.Type {A} renaming (_⇨_ to _↠_)
+
+private
+  variable
+    m n : ℕ
+
+Swizzle : ℕ → ℕ → Set
+Swizzle m n = Vec (Fin m) n
+
+swizzle : Swizzle m n → Vec A m → Vec A n
+swizzle s xs = map (lookup xs) s
+
+-- TODO: maybe make swizzle yield m ↠ n
+
+infix 0 _⇨_
+record _⇨_ (m n : ℕ) : Set where
+  constructor mk
+  field
+    unMk : Swizzle m n
+
+
+module vrouting-instances where
+
+  instance
+
+    H : Homomorphism _⇨_ _↠_
+    H = record { Fₘ = mk ∘ swizzle ∘ unMk } where open _⇨_
+
+    equivalent : Equivalent _ _⇨_
+    equivalent = H-equiv H

--- a/Vector/Homomorphism.agda
+++ b/Vector/Homomorphism.agda
@@ -1,0 +1,81 @@
+{-# OPTIONS --safe --without-K #-}
+
+module Vector.Homomorphism {A : Set} where
+
+open import Data.Unit using (tt)
+open import Data.Product using (_,_)
+open import Data.Nat
+open import Data.Vec
+open import Data.Vec.Properties
+open import Relation.Binary.PropositionalEquality
+open ≡-Reasoning
+
+open import Categorical.Raw
+open import Categorical.Homomorphism hiding (refl)
+open import Functions
+
+open import Vector.Raw {A} public
+
+private
+
+  app : ∀ {m n : ℕ} → Vec A m × Vec A n → Vec A (m + n)
+  app (u , v) = u ++ v
+
+  app⁻¹ : ∀ {m n : ℕ} → Vec A (m + n) → Vec A m × Vec A n
+  app⁻¹ {m} = take m ▵ drop m
+
+  take∘app : ∀ {m n : ℕ} → take m {n} ∘ app ≈ exl
+  take∘app {zero } {n} ([] , v) = refl
+  take∘app {suc m} {n} (x ∷ u , v) =
+    begin
+      take (suc m) (x ∷ u ++ v)
+    ≡⟨ unfold-take m {n} x (u ++ v) ⟩
+      x ∷ take m (u ++ v)
+    ≡⟨ cong (x ∷_) (take∘app (u , v)) ⟩
+      x ∷ u
+    ∎
+
+  drop∘app : ∀ {m n : ℕ} → drop m {n} ∘ app ≈ exr
+  drop∘app {zero } {n} ([] , v) = refl
+  drop∘app {suc m} {n} (x ∷ u , v) =
+    begin
+      drop (suc m) (x ∷ u ++ v)
+    ≡⟨ unfold-drop m {n} x (u ++ v) ⟩
+      drop m (u ++ v)
+    ≡⟨ drop∘app (u , v) ⟩
+      v
+    ∎
+
+  app⁻¹∘app : ∀ {m n : ℕ} → app⁻¹ ∘ app {m}{n} ≈ id
+  app⁻¹∘app {m} uv = cong₂ _,_ (take∘app uv) (drop∘app uv)
+
+
+module vec-homomorphism-instances where
+
+  instance
+
+    categoryH : CategoryH _⇨_ Function
+    categoryH = record
+      { F-id = λ _ → refl
+      ; F-∘  = λ _ → refl 
+      }
+
+    pH : ProductsH ℕ Function
+    pH = record
+      { ε     = λ { tt → [] }
+      ; μ     = app
+      ; ε⁻¹   = λ { [] → tt }
+      ; μ⁻¹   = app⁻¹
+      ; ε⁻¹∘ε = λ { tt → refl }
+      ; ε∘ε⁻¹ = λ { [] → refl } 
+      ; μ⁻¹∘μ = app⁻¹∘app
+      ; μ∘μ⁻¹ = λ {a = m} → take-drop-id m
+      }
+
+    cartesian : CartesianH _⇨_ Function
+    cartesian = record
+      { F-!   = λ _ → refl
+      ; F-▵   = λ _ → refl
+      ; F-exl = take∘app
+      ; F-exr = drop∘app
+      }

--- a/Vector/Laws.agda
+++ b/Vector/Laws.agda
@@ -1,0 +1,19 @@
+{-# OPTIONS --safe --without-K #-}
+
+module Vector.Laws {A : Set} where
+
+open import Categorical.Raw
+import Categorical.Laws as L
+open import Categorical.MakeLawful
+
+open import Functions
+open import Vector.Homomorphism {A} public
+
+-- Inherit lawfulness from functions
+
+module vector-laws-instances where
+
+  instance
+
+    category : L.Category _⇨_
+    category = LawfulCategoryᶠ Function

--- a/Vector/Raw.agda
+++ b/Vector/Raw.agda
@@ -1,0 +1,34 @@
+{-# OPTIONS --safe --without-K #-}
+
+module Vector.Raw {A : Set} where
+
+open import Data.Nat
+open import Data.Vec
+
+open import Categorical.Raw
+open import Categorical.Equiv
+open import Functions
+
+open import Vector.Type {A} public
+
+module vec-raw-instances where
+
+  instance
+
+    products : Products ℕ
+    products = record { ⊤ = zero ; _×_ = _+_ }
+
+    category : Category _⇨_
+    category = record
+      { id  = mk id
+      ; _∘_ = λ (mk g) (mk f) → mk (g ∘ f)
+      }
+
+    cartesian : Cartesian _⇨_
+    cartesian =
+      record
+        { !   = mk (λ _ → [])
+        ; _▵_ = λ (mk f) (mk g) → mk (λ xs → f xs ++ g xs)
+        ; exl = mk (take _)
+        ; exr = mk (drop _)
+        }

--- a/Vector/Type.agda
+++ b/Vector/Type.agda
@@ -1,0 +1,32 @@
+{-# OPTIONS --safe --without-K #-}
+
+module Vector.Type {A : Set} where
+
+open import Categorical.Raw
+open import Categorical.Homomorphism
+open import Functions.Raw
+
+open import Data.Nat
+open import Data.Vec
+
+infixr 1 _⇨_
+record _⇨_ (m n : ℕ) : Set where
+  constructor mk
+  field
+    unMk : Vec A m → Vec A n
+
+module vector-instances where
+
+  instance
+
+    Hₒ-id : Homomorphismₒ ℕ ℕ
+    Hₒ-id = id-Hₒ
+
+    Hₒ : Homomorphismₒ ℕ Set
+    Hₒ = record { Fₒ = Vec A }
+
+    H : Homomorphism _⇨_ Function
+    H = record { Fₘ = unMk } where open _⇨_
+
+    equivalent : Equivalent _ _⇨_
+    equivalent = H-equiv H


### PR DESCRIPTION
I want to simplify circuits so they can only consume and produce bit vectors. High-level algorithms can still be designed in the category of functions and then related to circuits by a functor from circuits to functions.

This PR adds two categories:

-   `Vector`: functions on `Vec A i` with `ℕ` as objects (with homomorphism to regular functions).
-   `VRouting` (to be renamed later to “`Routing`”): a representation of vector functions for which each output bit comes from a statically-known input bit. This idea comes from [Π-Ware](https://gitlab.com/joaopizani/piware-agda).

I’ve been using a more convenient generalization of `VRouting` with nested products (the current `Routing`), but now I want to get that convenience from a comma category construction instead.
